### PR TITLE
Implement column sorting for permits datatable

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { PageInfo } from '../../types';
-import { Column, OrderDirection } from '../types';
+import { OrderBy, PageInfo } from '../../types';
+import { Column } from '../types';
 import styles from './DataTable.module.scss';
 import Paginator from './paginator/Paginator';
 import Table from './table/Table';
@@ -10,11 +10,10 @@ export interface DataTableProps<T> {
   data: T[];
   loading: boolean;
   pageInfo?: PageInfo;
-  orderBy?: string;
-  orderDirection?: OrderDirection;
+  orderBy?: OrderBy;
   rowIdSelector: (row: T) => string | number;
   onPage?: (page: number) => void;
-  onOrderBy: (orderBy: string, orderDirection: OrderDirection) => void;
+  onOrderBy: (orderBy: OrderBy) => void;
 }
 
 const DataTable = <T,>({
@@ -23,7 +22,6 @@ const DataTable = <T,>({
   loading,
   pageInfo,
   orderBy,
-  orderDirection,
   rowIdSelector,
   onPage,
   onOrderBy,
@@ -35,7 +33,6 @@ const DataTable = <T,>({
       loading={loading}
       orderBy={orderBy}
       rowIdSelector={rowIdSelector}
-      orderDirection={orderDirection}
       onOrderBy={onOrderBy}
     />
     {pageInfo && onPage && <Paginator pageInfo={pageInfo} onPage={onPage} />}

--- a/src/components/common/table/ColumnHeader.tsx
+++ b/src/components/common/table/ColumnHeader.tsx
@@ -1,35 +1,29 @@
-import { IconAngleUp, IconDocument } from 'hds-react';
+import { IconAngleDown, IconAngleUp } from 'hds-react';
 import React from 'react';
 import { OrderDirection } from '../../types';
 import styles from './ColumnHeader.module.scss';
 
 export interface ColumnHeaderProps {
   title: string;
-  field: string;
-  direction?: OrderDirection | null;
-  onOrderBy: (field: string, direction: OrderDirection) => void;
+  sortable: boolean;
+  orderDirection?: OrderDirection | null;
+  onClick?: () => void;
 }
 
 const ColumnHeader = ({
   title,
-  field,
-  direction,
-  onOrderBy,
+  sortable,
+  orderDirection,
+  onClick,
 }: ColumnHeaderProps): React.ReactElement => (
-  <th
-    onClick={() =>
-      onOrderBy(
-        field,
-        direction === OrderDirection.ASC
-          ? OrderDirection.DESC
-          : OrderDirection.ASC
-      )
-    }>
+  <th style={{ cursor: sortable ? 'pointer' : 'default' }} onClick={onClick}>
     <div className={styles['column-header']}>
       <span>{title}</span>
-      {direction === null && <IconAngleUp className={styles['hover-icon']} />}
-      {direction === OrderDirection.DESC && <IconDocument />}
-      {direction === OrderDirection.ASC && <IconAngleUp />}
+      {sortable && orderDirection === null && (
+        <IconAngleUp className={styles['hover-icon']} />
+      )}
+      {sortable && orderDirection === OrderDirection.DESC && <IconAngleDown />}
+      {sortable && orderDirection === OrderDirection.ASC && <IconAngleUp />}
     </div>
   </th>
 );

--- a/src/components/common/table/HeaderRow.tsx
+++ b/src/components/common/table/HeaderRow.tsx
@@ -1,29 +1,52 @@
 import React from 'react';
+import { OrderBy } from '../../../types';
 import { Column, OrderDirection } from '../../types';
 import ColumnHeader from './ColumnHeader';
 import styles from './HeaderRow.module.scss';
 
 export interface HeaderRowProps<T> {
   columns: Column<T>[];
-  orderBy?: string;
+  orderBy?: OrderBy;
   orderDirection?: OrderDirection;
-  onOrderBy: (field: string, orderDirection: OrderDirection) => void;
+  onOrderBy: (orderBy: OrderBy) => void;
+}
+
+function getNextOrderDirection(
+  orderField: string,
+  currentOrderBy?: OrderBy
+): OrderDirection {
+  if (!currentOrderBy || orderField !== currentOrderBy?.field) {
+    return OrderDirection.ASC;
+  }
+  return currentOrderBy?.orderDirection === OrderDirection.ASC
+    ? OrderDirection.DESC
+    : OrderDirection.ASC;
 }
 
 const HeaderRow = <T,>({
   columns,
   orderBy,
-  orderDirection,
   onOrderBy,
 }: HeaderRowProps<T>): React.ReactElement => (
   <tr className={styles['header-row']}>
-    {columns.map(({ name, field }) => (
+    {columns.map(({ name, field, orderFields }) => (
       <ColumnHeader
         key={field}
         title={name}
-        field={field}
-        direction={orderBy === field ? orderDirection : null}
-        onOrderBy={onOrderBy}
+        sortable={orderFields !== undefined}
+        orderDirection={
+          orderBy?.field === field ? orderBy?.orderDirection : null
+        }
+        onClick={
+          orderFields
+            ? () =>
+                onOrderBy({
+                  field,
+                  orderFields,
+                  orderDirection: getNextOrderDirection(field, orderBy),
+                })
+            : undefined
+        }
       />
     ))}
   </tr>

--- a/src/components/common/table/Table.tsx
+++ b/src/components/common/table/Table.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Column, OrderDirection } from '../../types';
+import { OrderBy } from '../../../types';
+import { Column } from '../../types';
 import HeaderRow from './HeaderRow';
 import NoDataRow from './NoDataRow';
 import styles from './Table.module.scss';
@@ -9,10 +10,9 @@ export interface TableProps<T> {
   columns: Column<T>[];
   data: T[] | undefined;
   loading: boolean;
-  orderBy?: string;
-  orderDirection?: OrderDirection;
+  orderBy?: OrderBy;
   rowIdSelector: (row: T) => string | number;
-  onOrderBy: (orderBy: string, orderDirection: OrderDirection) => void;
+  onOrderBy: (orderBy: OrderBy) => void;
 }
 
 const Table = <T,>({
@@ -20,7 +20,6 @@ const Table = <T,>({
   data,
   loading,
   orderBy,
-  orderDirection,
   rowIdSelector,
   onOrderBy,
 }: TableProps<T>): React.ReactElement => {
@@ -37,12 +36,7 @@ const Table = <T,>({
   return (
     <table className={styles.table}>
       <thead>
-        <HeaderRow
-          columns={columns}
-          orderBy={orderBy}
-          orderDirection={orderDirection}
-          onOrderBy={onOrderBy}
-        />
+        <HeaderRow columns={columns} orderBy={orderBy} onOrderBy={onOrderBy} />
       </thead>
       <tbody className={styles['table-body']}>{tableBody}</tbody>
     </table>

--- a/src/components/permits/PermitsDataTable.tsx
+++ b/src/components/permits/PermitsDataTable.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageInfo, Permit } from '../../types';
+import { OrderBy, PageInfo, Permit } from '../../types';
 import { formatDateTime, getPrimaryAddress } from '../../utils';
 import DataTable from '../common/DataTable';
-import { Column, OrderDirection } from '../types';
+import { Column } from '../types';
 
 export interface PermitsDataTableProps {
   permits: Permit[];
   pageInfo?: PageInfo;
   loading: boolean;
+  orderBy?: OrderBy;
   onPage?: (page: number) => void;
-  onOrderBy: (field: string, orderDirection: OrderDirection) => void;
+  onOrderBy: (orderBy: OrderBy) => void;
 }
 
 const PermitsDataTable = ({
   permits,
   pageInfo,
   loading,
+  orderBy,
   onPage,
   onOrderBy,
 }: PermitsDataTableProps): React.ReactElement => {
@@ -26,49 +28,52 @@ const PermitsDataTable = ({
       name: 'Name',
       field: 'name',
       selector: ({ customer }) => `${customer.firstName} ${customer.lastName}`,
-      sortable: true,
+      orderFields: ['customer__first_name', 'customer__last_name'],
     },
     {
       name: 'Hetu',
       field: 'nationalIdNumber',
       selector: ({ customer }) => customer.nationalIdNumber,
-      sortable: true,
+      orderFields: ['customer__national_id_number'],
     },
     {
       name: 'Registration number',
       field: 'registrationNumber',
       selector: row => row.vehicle.registrationNumber,
-      sortable: true,
+      orderFields: ['vehicle__registration_number'],
     },
     {
       name: 'Address',
       field: 'address',
       selector: ({ customer }) => getPrimaryAddress(customer, i18n.language),
-      sortable: true,
+      orderFields: [
+        'customer__primary_address__street_name',
+        'customer__primary_address__street_number',
+      ],
     },
     {
       name: 'Zone',
       field: 'parkingZone',
       selector: row => row.parkingZone.name,
-      sortable: true,
+      orderFields: ['parking_zone__name'],
     },
     {
       name: 'Start time',
       field: 'startTime',
       selector: row => formatDateTime(row.startTime),
-      sortable: true,
+      orderFields: ['start_time'],
     },
     {
       name: 'End time',
       field: 'endTime',
       selector: row => (row.endTime ? formatDateTime(row.endTime) : '-'),
-      sortable: true,
+      orderFields: ['end_time'],
     },
     {
       name: 'Status',
       field: 'status',
       selector: row => row.status,
-      sortable: true,
+      orderFields: ['status'],
     },
   ];
 
@@ -79,6 +84,7 @@ const PermitsDataTable = ({
         loading={loading}
         pageInfo={pageInfo}
         columns={columns}
+        orderBy={orderBy}
         rowIdSelector={(row: Permit) => row.identifier}
         onPage={onPage}
         onOrderBy={onOrderBy}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 
 export enum OrderDirection {
-  ASC,
-  DESC,
+  ASC = 'ASC',
+  DESC = 'DESC',
 }
 export interface Column<T> {
   name: string;
   field: string;
   selector: (row: T) => React.ReactNode;
-  sortable: boolean;
+  orderFields?: string[];
 }

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -1,12 +1,12 @@
 import { gql, useQuery } from '@apollo/client';
 import React, { useState } from 'react';
 import PermitsDataTable from '../components/permits/PermitsDataTable';
-import { PermitsQueryData } from '../types';
+import { OrderBy, PermitsQueryData, PermitsQueryVariables } from '../types';
 import { makePrivate } from './utils';
 
 const PERMITS_QUERY = gql`
-  query GetPermits($pageInput: PageInput!) {
-    permits(pageInput: $pageInput) {
+  query GetPermits($pageInput: PageInput!, $orderBy: OrderByInput) {
+    permits(pageInput: $pageInput, orderBy: $orderBy) {
       objects {
         identifier
         startTime
@@ -43,8 +43,13 @@ const PERMITS_QUERY = gql`
 
 const Permits = (): React.ReactElement => {
   const [page, setPage] = useState(1);
+  const [orderBy, setOrderBy] = useState<OrderBy>();
+  const variables: PermitsQueryVariables = {
+    pageInput: { page },
+    orderBy,
+  };
   const { loading, error, data } = useQuery<PermitsQueryData>(PERMITS_QUERY, {
-    variables: { pageInput: { page } },
+    variables,
   });
   if (error) {
     return <div>{JSON.stringify(error)}</div>;
@@ -54,10 +59,9 @@ const Permits = (): React.ReactElement => {
       permits={data?.permits.objects || []}
       pageInfo={data?.permits.pageInfo}
       loading={loading}
+      orderBy={orderBy}
       onPage={newPage => setPage(newPage)}
-      onOrderBy={() => {
-        // do nothing yet
-      }}
+      onOrderBy={newOrderBy => setOrderBy(newOrderBy)}
     />
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { OrderDirection } from './components/types';
+
 export interface Address {
   streetName: string;
   streetNumber: number;
@@ -51,4 +53,20 @@ export interface PagedPermits {
 
 export interface PermitsQueryData {
   permits: PagedPermits;
+}
+
+export interface OrderBy {
+  field: string;
+  orderFields: string[];
+  orderDirection: OrderDirection;
+}
+
+export interface PageInput {
+  page: number;
+  pageSize?: number;
+}
+
+export interface PermitsQueryVariables {
+  pageInput: PageInput;
+  orderBy?: OrderBy;
 }


### PR DESCRIPTION
This PR implements the column sorting for permits datatable in front page.  When a user hovers over a sortable column, the mouse cursor switch to pointer, and a half-transparent angle icon is shown to the user.

When the user clicks on an unordered column, the datatable will sort the results by this column in ascending order. And if the user clicks again the same column, it will sort the results in desc order.

Related backend MR:

https://github.com/City-of-Helsinki/parking-permits/pull/68

Refs: PV-217

https://user-images.githubusercontent.com/1997039/136785488-e8d61437-eac2-4688-9e8a-421a13b8760d.mov


