### PR TITLE
Implement end permit UI

### DIFF
--- a/src/components/common/ZoneSelect.tsx
+++ b/src/components/common/ZoneSelect.tsx
@@ -14,7 +14,7 @@ const ZONES_QUERY = gql`
       name
       description
       descriptionSv
-      price
+      residentPrice
     }
   }
 `;

--- a/src/components/createResidentPermit/VehicleInfo.tsx
+++ b/src/components/createResidentPermit/VehicleInfo.tsx
@@ -129,14 +129,18 @@ const VehicleInfo = ({
                 <div className={styles.priceInfo}>
                   {vehicle.isLowEmission && (
                     <div className={styles.discountPrice}>
-                      {zone ? formatMonthlyPrice(zone.price / 2) : '-'}
+                      {zone ? formatMonthlyPrice(zone.residentPrice / 2) : '-'}
                     </div>
                   )}
                   <div className={styles.originalPrice}>
                     {vehicle.isLowEmission ? (
-                      <del>{zone ? formatMonthlyPrice(zone.price) : '-'}</del>
+                      <del>
+                        {zone ? formatMonthlyPrice(zone.residentPrice) : '-'}
+                      </del>
                     ) : (
-                      <span>{zone ? formatMonthlyPrice(zone.price) : '-'}</span>
+                      <span>
+                        {zone ? formatMonthlyPrice(zone.residentPrice) : '-'}
+                      </span>
                     )}
                   </div>
                 </div>

--- a/src/components/permitDetail/EndPermitDialog.module.scss
+++ b/src/components/permitDetail/EndPermitDialog.module.scss
@@ -1,0 +1,13 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.chooseEndTypeLabel {
+  margin-bottom: $spacing-s;
+}
+
+.currentPeriodEndTime {
+  margin-left: $spacing-l;
+}
+
+.endOption {
+  margin-bottom: $spacing-s;
+}

--- a/src/components/permitDetail/EndPermitDialog.tsx
+++ b/src/components/permitDetail/EndPermitDialog.tsx
@@ -1,0 +1,68 @@
+import { Button, Dialog, RadioButton } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PermitEndType } from '../../types';
+import { formatDateTimeDisplay } from '../../utils';
+import styles from './EndPermitDialog.module.scss';
+
+const T_PATH = 'components.permitDetail.endPermitDialog';
+
+interface EndPermitDialogProps {
+  isOpen: boolean;
+  currentPeriodEndTime: string;
+  onCancel: () => void;
+  onConfirm: (endType: PermitEndType) => void;
+}
+
+const EndPermitDialog = ({
+  isOpen,
+  currentPeriodEndTime,
+  onCancel,
+  onConfirm,
+}: EndPermitDialogProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const [endType, setEndType] = useState<PermitEndType | undefined>();
+  return (
+    <Dialog
+      id="confirm-end-permit"
+      aria-labelledby="confirmEndPermit"
+      isOpen={isOpen}>
+      <Dialog.Header id="confirmEndPermit" title={t(`${T_PATH}.title`)} />
+      <Dialog.Content>
+        <div className={styles.chooseEndTypeLabel}>
+          {t(`${T_PATH}.choosePermitEndType`)}
+        </div>
+        <RadioButton
+          id="endImmediately"
+          name="endType"
+          label={t(`${T_PATH}.endImmediately`)}
+          value={PermitEndType.IMMEDIATELY}
+          checked={endType === PermitEndType.IMMEDIATELY}
+          onChange={e => setEndType(e.target.value as PermitEndType)}
+        />
+        <RadioButton
+          id="endAfterCurrentPeriod"
+          name="endType"
+          label={t(`${T_PATH}.endAfterCurrentPeriod`)}
+          value={PermitEndType.AFTER_CURRENT_PERIOD}
+          checked={endType === PermitEndType.AFTER_CURRENT_PERIOD}
+          onChange={e => setEndType(e.target.value as PermitEndType)}
+        />
+        <div className={styles.currentPeriodEndTime}>
+          {formatDateTimeDisplay(currentPeriodEndTime)}
+        </div>
+      </Dialog.Content>
+      <Dialog.ActionButtons>
+        <Button
+          disabled={!endType}
+          onClick={() => endType && onConfirm(endType)}>
+          {t(`${T_PATH}.continue`)}
+        </Button>
+        <Button variant="secondary" onClick={() => onCancel()}>
+          {t(`${T_PATH}.cancel`)}
+        </Button>
+      </Dialog.ActionButtons>
+    </Dialog>
+  );
+};
+export default EndPermitDialog;

--- a/src/components/permitDetail/EndPermitDialog.tsx
+++ b/src/components/permitDetail/EndPermitDialog.tsx
@@ -9,6 +9,7 @@ const T_PATH = 'components.permitDetail.endPermitDialog';
 
 interface EndPermitDialogProps {
   isOpen: boolean;
+  canEndAfterCurrentPeriod: boolean;
   currentPeriodEndTime: string;
   onCancel: () => void;
   onConfirm: (endType: PermitEndType) => void;
@@ -16,6 +17,7 @@ interface EndPermitDialogProps {
 
 const EndPermitDialog = ({
   isOpen,
+  canEndAfterCurrentPeriod,
   currentPeriodEndTime,
   onCancel,
   onConfirm,
@@ -43,6 +45,7 @@ const EndPermitDialog = ({
         <RadioButton
           id="endAfterCurrentPeriod"
           name="endType"
+          disabled={!canEndAfterCurrentPeriod}
           label={t(`${T_PATH}.endAfterCurrentPeriod`)}
           value={PermitEndType.AFTER_CURRENT_PERIOD}
           checked={endType === PermitEndType.AFTER_CURRENT_PERIOD}

--- a/src/components/permitDetail/PermitInfo.tsx
+++ b/src/components/permitDetail/PermitInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { PermitDetail } from '../../types';
+import { PermitDetail, PermitEndType } from '../../types';
 import { formatDateTimeDisplay } from '../../utils';
 import Divider from '../common/Divider';
 import StatusLabel from '../common/StatusLabel';
@@ -10,15 +10,32 @@ import styles from './PermitInfo.module.scss';
 const T_PATH = 'components.permitDetail.permitInfo';
 export interface PermitInfoProps {
   className?: string;
+  endType?: PermitEndType;
   permit: PermitDetail;
 }
 
 const PermitInfo = ({
   className,
+  endType,
   permit,
 }: PermitInfoProps): React.ReactElement => {
   const { t } = useTranslation();
-  const { contractType, monthCount, startTime, endTime, status } = permit;
+  const {
+    contractType,
+    monthCount,
+    startTime,
+    endTime,
+    status,
+    currentPeriodEndTime,
+  } = permit;
+  let endTimeValue = '';
+  if (endType === PermitEndType.IMMEDIATELY) {
+    endTimeValue = t(`${T_PATH}.now`);
+  } else if (endTimeValue === PermitEndType.AFTER_CURRENT_PERIOD) {
+    endTimeValue = formatDateTimeDisplay(currentPeriodEndTime);
+  } else {
+    endTimeValue = endTime ? formatDateTimeDisplay(endTime) : '-';
+  }
   const contractTypeLabelMapping = {
     FIXED_PERIOD: t('contractType.fixedPeriod'),
     OPEN_ENDED: t('contractType.openEnded'),
@@ -38,7 +55,7 @@ const PermitInfo = ({
     },
     {
       label: t(`${T_PATH}.endTime`),
-      value: endTime ? formatDateTimeDisplay(endTime) : '-',
+      value: endTimeValue,
     },
     {
       label: t(`${T_PATH}.status`),

--- a/src/components/permitDetail/PermitInfo.tsx
+++ b/src/components/permitDetail/PermitInfo.tsx
@@ -31,7 +31,7 @@ const PermitInfo = ({
   let endTimeValue = '';
   if (endType === PermitEndType.IMMEDIATELY) {
     endTimeValue = t(`${T_PATH}.now`);
-  } else if (endTimeValue === PermitEndType.AFTER_CURRENT_PERIOD) {
+  } else if (endType === PermitEndType.AFTER_CURRENT_PERIOD) {
     endTimeValue = formatDateTimeDisplay(currentPeriodEndTime);
   } else {
     endTimeValue = endTime ? formatDateTimeDisplay(endTime) : '-';

--- a/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
@@ -1,0 +1,42 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.title {
+  font-size: $fontsize-body-xl;
+  margin-bottom: $spacing-s;
+}
+
+.infoBox {
+  padding: $spacing-s 0;
+  background-color: $color-silver-light;
+
+  .orderRemaining {
+    padding: 0 $spacing-s;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-weight: bold;
+  }
+
+  .orderRemainingDetail {
+    padding: 0 $spacing-s;
+  }
+
+  .refundDescription {
+    padding: 0 $spacing-s;
+    margin-top: $spacing-s;
+  }
+
+  .refund {
+    padding: $spacing-s;
+    margin-top: $spacing-m;
+    background-color: $color-coat-of-arms-light;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-weight: bold;
+  }
+
+  .iban {
+    padding: $spacing-s;
+  }
+}

--- a/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
@@ -36,6 +36,10 @@
     font-weight: bold;
   }
 
+  .refunded {
+    font-size: $fontsize-body-l;
+  }
+
   .iban {
     padding: $spacing-s;
   }

--- a/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.module.scss
@@ -37,6 +37,7 @@
   }
 
   .refunded {
+    padding: $spacing-s;
     font-size: $fontsize-body-l;
   }
 

--- a/src/components/permitDetail/RefundInfoFixedPeriod.tsx
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.tsx
@@ -20,7 +20,7 @@ const RefundInfoFixedPeriod = ({
   onChangeIban,
 }: RefundInfoFixedPeriodProps): React.ReactElement => {
   const { t } = useTranslation();
-  const { monthsLeft, monthlyPrice } = permit;
+  const { monthsLeft, monthlyPrice, hasRefund } = permit;
   const refundAmount = `${(-monthsLeft * monthlyPrice).toFixed(2)} €`;
   const amountLabel = t(`${T_PATH}.monthCount`, {
     count: monthsLeft,
@@ -44,14 +44,18 @@ const RefundInfoFixedPeriod = ({
           <div className={styles.refundLabel}>{t(`${T_PATH}.refund`)}</div>
           <div className={styles.refundAmount}>{refundAmount}</div>
         </div>
-        <TextInput
-          className={styles.iban}
-          required
-          id="iban"
-          label="IBAN"
-          value={iban}
-          onChange={e => onChangeIban(e.target.value)}
-        />
+        {hasRefund ? (
+          <div className={styles.refunded}>{t(`${T_PATH}.refunded`)}</div>
+        ) : (
+          <TextInput
+            className={styles.iban}
+            required
+            id="iban"
+            label="IBAN"
+            value={iban}
+            onChange={e => onChangeIban(e.target.value)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/permitDetail/RefundInfoFixedPeriod.tsx
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.tsx
@@ -1,0 +1,59 @@
+import { TextInput } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { PermitDetail } from '../../types';
+import { formatMonthlyPrice } from '../../utils';
+import styles from './RefundInfoFixedPeriod.module.scss';
+
+const T_PATH = 'components.permitDetail.refundInfoFixedPeriod';
+export interface RefundInfoFixedPeriodProps {
+  className?: string;
+  iban: string;
+  permit: PermitDetail;
+  onChangeIban: (iban: string) => void;
+}
+
+const RefundInfoFixedPeriod = ({
+  className,
+  iban,
+  permit,
+  onChangeIban,
+}: RefundInfoFixedPeriodProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const { monthsLeft, monthlyPrice } = permit;
+  const refundAmount = `${(-monthsLeft * monthlyPrice).toFixed(2)} €`;
+  const amountLabel = t(`${T_PATH}.monthCount`, {
+    count: monthsLeft,
+  });
+  const refundDetail = `${amountLabel}, ${formatMonthlyPrice(monthlyPrice)}`;
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+      <div className={styles.infoBox}>
+        <div className={styles.orderRemaining}>
+          <div className={styles.orderRemainingLabel}>
+            {t(`${T_PATH}.orderRemaining`)}
+          </div>
+          <div className={styles.orderRemainingAmount}>{refundAmount}</div>
+        </div>
+        <div className={styles.orderRemainingDetail}>{refundDetail}</div>
+        <div className={styles.refundDescription}>
+          * {t(`${T_PATH}.orderRemaingDescription`)}
+        </div>
+        <div className={styles.refund}>
+          <div className={styles.refundLabel}>{t(`${T_PATH}.refund`)}</div>
+          <div className={styles.refundAmount}>{refundAmount}</div>
+        </div>
+        <TextInput
+          className={styles.iban}
+          required
+          id="iban"
+          label="IBAN"
+          value={iban}
+          onChange={e => onChangeIban(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+};
+export default RefundInfoFixedPeriod;

--- a/src/components/permitDetail/RefundInfoOpenEnded.module.scss
+++ b/src/components/permitDetail/RefundInfoOpenEnded.module.scss
@@ -1,0 +1,29 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.title {
+  font-size: $fontsize-body-xl;
+  margin-bottom: $spacing-s;
+}
+
+.infoBox {
+  padding: $spacing-s 0;
+  background-color: $color-silver-light;
+
+  .monthlyPrice {
+    padding: 0 $spacing-s;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-weight: bold;
+  }
+
+  .refund {
+    padding: $spacing-s;
+    margin-top: $spacing-m;
+    background-color: $color-coat-of-arms-light;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-weight: bold;
+  }
+}

--- a/src/components/permitDetail/RefundInfoOpenEnded.tsx
+++ b/src/components/permitDetail/RefundInfoOpenEnded.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { PermitDetail } from '../../types';
+import { formatMonthlyPrice } from '../../utils';
+import styles from './RefundInfoOpenEnded.module.scss';
+
+const T_PATH = 'components.permitDetail.refundInfoOpenEnded';
+export interface RefundInfoOpenEndedProps {
+  className?: string;
+  permit: PermitDetail;
+}
+
+const RefundInfoOpenEnded = ({
+  className,
+  permit,
+}: RefundInfoOpenEndedProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const { monthlyPrice } = permit;
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+      <div className={styles.infoBox}>
+        <div className={styles.monthlyPrice}>
+          <div className={styles.monthlyPriceLabel}>
+            {t(`${T_PATH}.monthlyPrice`)}
+          </div>
+          <div className={styles.monthlyPriceAmount}>
+            {formatMonthlyPrice(monthlyPrice)}
+          </div>
+        </div>
+        <div className={styles.refund}>
+          <div className={styles.refundLabel}>{t(`${T_PATH}.refund`)}</div>
+          <div className={styles.refundAmount}>0 €</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default RefundInfoOpenEnded;

--- a/src/components/permitDetail/VehicleInfo.tsx
+++ b/src/components/permitDetail/VehicleInfo.tsx
@@ -19,7 +19,7 @@ const VehicleInfo = ({
   const { t } = useTranslation();
   const { vehicle, parkingZone, consentLowEmissionAccepted } = permit;
   const { isLowEmission } = vehicle;
-  const { price } = parkingZone;
+  const { residentPrice } = parkingZone;
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
@@ -35,14 +35,14 @@ const VehicleInfo = ({
         <div className={styles.priceInfo}>
           {isLowEmission && (
             <span>
-              <strong>{formatMonthlyPrice(price / 2)}</strong>
+              <strong>{formatMonthlyPrice(residentPrice / 2)}</strong>
             </span>
           )}
           <span
             style={{
               textDecoration: isLowEmission ? 'line-trhough' : 'none',
             }}>
-            {formatMonthlyPrice(price)}
+            {formatMonthlyPrice(residentPrice)}
           </span>
         </div>
         <Checkbox

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -102,6 +102,7 @@
         "monthCount_other": "{{count}} months",
         "orderRemaingDescription": "The price only accounts for remaining full months of the order",
         "orderRemaining": "Paid order remaining",
+        "refunded": "Refunded",
         "title": "Price"
       },
       "refundInfoOpenEnded": {
@@ -165,12 +166,12 @@
       "totalPrice": "Total price"
     },
     "endPermit": {
-      "title": "Summary",
       "cancel": "Cancel",
       "endPermit": "End permit",
       "permitId": "Permit ID",
       "permits": "Permits",
-      "residentParkingPermit": "Resident parking permit"
+      "residentParkingPermit": "Resident parking permit",
+      "title": "Summary"
     },
     "login": {
       "login": "Login"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -78,6 +78,15 @@
         "title": "Customer information",
         "vehicleHolder": "Vehicle holder"
       },
+      "endPermitDialog": {
+        "cancel": "Cancel",
+        "choosePermitEndType": "Choose when the permit is ended",
+        "continue": "Continue",
+        "endAfterCurrentPeriod": "End permit after current period",
+        "endImmediately": "End permit immediately",
+        "refund": "Refund",
+        "title": "End permit"
+      },
       "permitInfo": {
         "additionalInfo": "Additional information",
         "contractType": "Contract type",
@@ -87,6 +96,18 @@
         "status": "Status",
         "title": "Permit information",
         "validPeriod": "Valid period"
+      },
+      "refundInfoFixedPeriod": {
+        "monthCount_one": "{{count}} month",
+        "monthCount_other": "{{count}} months",
+        "orderRemaingDescription": "The price only accounts for remaining full months of the order",
+        "orderRemaining": "Paid order remaining",
+        "title": "Price"
+      },
+      "refundInfoOpenEnded": {
+        "monthlyPrice": "Monthly price",
+        "refund": "Refund",
+        "title": "Price"
       },
       "vehicleInfo": {
         "consentLowEmissionDiscountText": "Permission for a 50% discount on other off-road parking when paying with parking applications",
@@ -143,11 +164,22 @@
       "save": "Save",
       "totalPrice": "Total price"
     },
+    "endPermit": {
+      "title": "Summary",
+      "cancel": "Cancel",
+      "endPermit": "End permit",
+      "permitId": "Permit ID",
+      "permits": "Permits",
+      "residentParkingPermit": "Resident parking permit"
+    },
     "login": {
       "login": "Login"
     },
     "permitDetail": {
       "changeHistory": "Change history",
+      "edit": "Edit",
+      "endPermit": "End permit",
+      "now": "Now",
       "permitId": "Permit ID",
       "permits": "Permits",
       "residentParkingPermit": "Resident parking permit"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -102,6 +102,7 @@
         "orderRemaingDescription": "Hinnassa huomioidaan tilauksen jäljellä olevat täydet kuukaudet.",
         "orderRemaining": "Maksettua tilausta jäljellä",
         "refund": "Palautus",
+        "refunded": "Palautetaan",
         "title": "Hinta"
       },
       "refundInfoOpenEnded": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -78,6 +78,14 @@
         "title": "Henkilötiedot",
         "vehicleHolder": "Ajoneuvon haltija"
       },
+      "endPermitDialog": {
+        "cancel": "Peruuta",
+        "choosePermitEndType": "Valitsen milloin tunnuksen voimassaolo päättyy",
+        "continue": "Jatka",
+        "endAfterCurrentPeriod": "Päätä tunnus kuluvan tilausjakson päätteeksi",
+        "endImmediately": "Päätä tunnus välittömästi",
+        "title": "Tunnuksen päättäminen"
+      },
       "permitInfo": {
         "additionalInfo": "Lisätiedot",
         "contractType": "Tunnuksen tyyppi",
@@ -87,6 +95,19 @@
         "status": "Tila",
         "title": "Tunnuksen tiedot",
         "validPeriod": "Voimassaoloaika"
+      },
+      "refundInfoFixedPeriod": {
+        "monthCount_one": "{{count}} kuukausi",
+        "monthCount_other": "{{count}} kuukautta",
+        "orderRemaingDescription": "Hinnassa huomioidaan tilauksen jäljellä olevat täydet kuukaudet.",
+        "orderRemaining": "Maksettua tilausta jäljellä",
+        "refund": "Palautus",
+        "title": "Hinta"
+      },
+      "refundInfoOpenEnded": {
+        "monthlyPrice": "Kuukausihinta",
+        "refund": "Palautus",
+        "title": "Hinta"
       },
       "vehicleInfo": {
         "consentLowEmissionDiscountText": "Lupa 50% alennukseen myös muusta kadunvarsipysäköinnistä pysäkointisovelluksilla maksaessa",
@@ -143,11 +164,22 @@
       "save": "Tallenna",
       "totalPrice": "Tunnuksen yhteissumma"
     },
+    "endPermit": {
+      "cancel": "Peruuta",
+      "endPermit": "Pääta tunnus",
+      "permitId": "Tunnus ID",
+      "permits": "Tunnukset",
+      "residentParkingPermit": "Asukaspysäköintitunnus",
+      "title": "Yhteenveto"
+    },
     "login": {
       "login": "Kirjaudu sisään"
     },
     "permitDetail": {
       "changeHistory": "Käsittelyhistoria",
+      "edit": "Muokkaa",
+      "endPermit": "Pääta tunnus",
+      "now": "Nyt",
       "permitId": "Tunnus ID",
       "permits": "Tunnukset",
       "residentParkingPermit": "Asukaspysäköintitunnus"

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -78,6 +78,14 @@
         "title": "Kundinformation",
         "vehicleHolder": "Fordonshållare"
       },
+      "endPermitDialog": {
+        "cancel": "Avbryt",
+        "choosePermitEndType": "Välj när tillståndet upphör",
+        "continue": "Fortsätt",
+        "endAfterCurrentPeriod": "Sluttillstånd efter aktuell period",
+        "endImmediately": "Avsluta tillstånd omedelbart",
+        "title": "Sluttillstånd"
+      },
       "permitInfo": {
         "additionalInfo": "Ytterligare information",
         "contractType": "Kontraktstyp",
@@ -87,6 +95,19 @@
         "status": "Status",
         "title": "Tillståndsinformation",
         "validPeriod": "Giltig period"
+      },
+      "refundInfoFixedPeriod": {
+        "monthCount_one": "{{count}} månad",
+        "monthCount_other": "{{count}} månader",
+        "orderRemaingDescription": "Priset tar hänsyn till de återstående hela månaderna av beställningen.",
+        "orderRemaining": "Betald order återstår",
+        "refund": "Återbetalning",
+        "title": "Pris"
+      },
+      "refundInfoOpenEnded": {
+        "monthlyPrice": "Månadspris",
+        "refund": "Återbetalning",
+        "title": "Pris"
       },
       "vehicleInfo": {
         "consentLowEmissionDiscountText": "Tillstånd för 50 % rabatt på annan terrängparkering vid betalning med parkeringsansökan",
@@ -143,11 +164,22 @@
       "save": "Spara",
       "totalPrice": "Totalpris"
     },
+    "endPermit": {
+      "cancel": "Avbryt",
+      "endPermit": "Sluttillstånd",
+      "permitId": "Tillstånds-ID",
+      "permits": "Tillstånd",
+      "residentParkingPermit": "Parkeringstillstånd för boende",
+      "title": "Sammanfattning"
+    },
     "login": {
       "login": "Logga in"
     },
     "permitDetail": {
       "changeHistory": "Ändringshistorik",
+      "edit": "Redigera",
+      "endPermit": "Sluttillstånd",
+      "now": "Nu",
       "permitId": "Tillstånds-ID",
       "permits": "Tillstånd",
       "residentParkingPermit": "Parkeringstillstånd för boende"

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -102,6 +102,7 @@
         "orderRemaingDescription": "Priset tar hänsyn till de återstående hela månaderna av beställningen.",
         "orderRemaining": "Betald order återstår",
         "refund": "Återbetalning",
+        "refunded": "Återbetalas",
         "title": "Pris"
       },
       "refundInfoOpenEnded": {

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -48,7 +48,7 @@ const CreateResidentPermit = (): React.ReactElement => {
       name: '',
       description: '',
       descriptionSv: '',
-      price: 0,
+      residentPrice: 0,
     },
     addressSecurityBan: false,
     nationalIdNumber: '',
@@ -117,8 +117,8 @@ const CreateResidentPermit = (): React.ReactElement => {
         count: permit.monthCount,
       });
       const price = vehicle?.isLowEmission
-        ? person.zone.price / 2
-        : person.zone.price;
+        ? person.zone.residentPrice / 2
+        : person.zone.residentPrice;
       const unitPriceLabel = formatMonthlyPrice(price);
       return `${amountLabel}, ${unitPriceLabel}`;
     }
@@ -127,8 +127,8 @@ const CreateResidentPermit = (): React.ReactElement => {
   const formatTotalPrice = () => {
     if (person?.zone && permit) {
       const price = vehicle?.isLowEmission
-        ? person.zone.price / 2
-        : person.zone.price;
+        ? person.zone.residentPrice / 2
+        : person.zone.residentPrice;
       return permit.monthCount * price;
     }
     return '-';

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -10,8 +10,8 @@ import PersonalInfo from '../components/createResidentPermit/PersonalInfo';
 import VehicleInfo from '../components/createResidentPermit/VehicleInfo';
 import { searchPerson, searchVechile } from '../services/mock';
 import {
-  CreateResidentPermitResponse,
   FixedPeriodResidentPermit,
+  MutationResponse,
   ParkingPermitStatus,
   PermitContractType,
   ResidentPermit,
@@ -33,7 +33,7 @@ const CREATE_RESIDENT_PERMIT_MUTATION = gql`
 
 const CreateResidentPermit = (): React.ReactElement => {
   const { t } = useTranslation();
-  const [createResidentPermit] = useMutation<CreateResidentPermitResponse>(
+  const [createResidentPermit] = useMutation<MutationResponse>(
     CREATE_RESIDENT_PERMIT_MUTATION
   );
   const navigate = useNavigate();

--- a/src/pages/EndPermit.module.scss
+++ b/src/pages/EndPermit.module.scss
@@ -1,0 +1,57 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  .status {
+    align-self: flex-start;
+    margin: $spacing-s 0;
+  }
+  .header {
+    margin-bottom: $spacing-s;
+    .customer {
+      display: flex;
+      align-items: center;
+
+      .customerName {
+        margin-right: $spacing-s;
+      }
+    }
+  }
+  .content {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: $spacing-5-xl;
+    .vehicleAndPerson {
+      flex: 1 1 33%;
+      margin-right: $spacing-m;
+      .vehicleInfo,
+      .customerInfo {
+        margin-bottom: $spacing-l;
+      }
+    }
+    .permitInfo {
+      flex: 1 1 33%;
+      margin-right: $spacing-m;
+    }
+    .refundInfo {
+      flex: 1 1 33%;
+    }
+  }
+  .footer {
+    padding: $spacing-m 0;
+    box-shadow: 0 -5px 5px -5px $color-black-30;
+    position: fixed;
+    width: 100%;
+    max-width: $breakpoint-xl;
+    left: calc(100% - $breakpoint-xl) / 2;
+    bottom: 0;
+    background-color: white;
+    display: flex;
+    flex-direction: row;
+
+    .spacer {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -1,0 +1,179 @@
+import { gql, useMutation, useQuery } from '@apollo/client';
+import { Button, IconPenLine } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+import { makePrivate } from '../auth/utils';
+import Breadcrumbs from '../components/common/Breadcrumbs';
+import StatusTag from '../components/common/StatusTag';
+import Zone from '../components/common/Zone';
+import CustomerInfo from '../components/permitDetail/CustomerInfo';
+import PermitInfo from '../components/permitDetail/PermitInfo';
+import RefundInfoFixedPeriod from '../components/permitDetail/RefundInfoFixedPeriod';
+import RefundInfoOpenEnded from '../components/permitDetail/RefundInfoOpenEnded';
+import VehicleInfo from '../components/permitDetail/VehicleInfo';
+import {
+  MutationResponse,
+  PermitContractType,
+  PermitDetailData,
+} from '../types';
+import { formatCustomerName } from '../utils';
+import styles from './EndPermit.module.scss';
+
+const T_PATH = 'pages.endPermit';
+
+const PERMIT_DETAIL_QUERY = gql`
+  query GetPermitDetail($permitId: ID!) {
+    permitDetail(permitId: $permitId) {
+      identifier
+      startTime
+      endTime
+      currentPeriodEndTime
+      status
+      consentLowEmissionAccepted
+      contractType
+      monthCount
+      monthsLeft
+      monthlyPrice
+      customer {
+        firstName
+        lastName
+        nationalIdNumber
+        email
+        phoneNumber
+        primaryAddress {
+          streetName
+          streetNameSv
+          streetNumber
+          city
+          citySv
+          postalCode
+        }
+      }
+      vehicle {
+        manufacturer
+        model
+        registrationNumber
+        isLowEmission
+        holder
+      }
+      parkingZone {
+        name
+        description
+        descriptionSv
+        residentPrice
+      }
+    }
+  }
+`;
+
+const END_PERMIT_MUTATION = gql`
+  mutation endPermit($permitId: Int!, $endType: PermitEndType!, $iban: String) {
+    endPermit(permitId: $permitId, endType: $endType, iban: $iban) {
+      success
+    }
+  }
+`;
+
+const EndPermit = (): React.ReactElement => {
+  const navigate = useNavigate();
+  const params = useParams();
+  const { t } = useTranslation();
+  const { id, endType } = params;
+  const variables = { permitId: id };
+  const [iban, setIban] = useState('');
+  const { loading, error, data } = useQuery<PermitDetailData>(
+    PERMIT_DETAIL_QUERY,
+    {
+      variables,
+    }
+  );
+  const [endPermit] = useMutation<MutationResponse>(END_PERMIT_MUTATION);
+  if (loading) {
+    return <div>loading...</div>;
+  }
+  if (error) {
+    return <div>{JSON.stringify(error)}</div>;
+  }
+  if (!data) {
+    return <div>No data</div>;
+  }
+  const { permitDetail } = data;
+  const { identifier, status, customer, parkingZone, contractType } =
+    permitDetail;
+  return (
+    <div className={styles.container}>
+      <Breadcrumbs>
+        <Link to="/permits">{t(`${T_PATH}.permits`)}</Link>
+        <span>{id}</span>
+      </Breadcrumbs>
+      <div className={styles.status}>
+        <StatusTag status={status} />
+      </div>
+      <div className={styles.header}>
+        <div className={styles.customer}>
+          <h2 className={styles.customerName}>
+            {formatCustomerName(customer)}
+          </h2>
+          <Zone name={parkingZone.name} />
+        </div>
+        <div className={styles.summary}>
+          <b>{t(`${T_PATH}.residentParkingPermit`)}</b>{' '}
+          <span>
+            {t(`${T_PATH}.permitId`)}: {id}
+          </span>
+        </div>
+      </div>
+      <div className={styles.content}>
+        <div className={styles.vehicleAndPerson}>
+          <VehicleInfo className={styles.vehicleInfo} permit={permitDetail} />
+          <CustomerInfo className={styles.customerInfo} permit={permitDetail} />
+        </div>
+        <PermitInfo className={styles.permitInfo} permit={permitDetail} />
+        {contractType === PermitContractType.FIXED_PERIOD && (
+          <RefundInfoFixedPeriod
+            className={styles.refundInfo}
+            iban={iban}
+            permit={permitDetail}
+            onChangeIban={newIban => setIban(newIban)}
+          />
+        )}
+        {contractType === PermitContractType.OPEN_ENDED && (
+          <RefundInfoOpenEnded
+            className={styles.refundInfo}
+            permit={permitDetail}
+          />
+        )}
+      </div>
+      <div className={styles.footer}>
+        <Button
+          className={styles.actionButton}
+          iconLeft={<IconPenLine />}
+          onClick={() => navigate(`/permits/${id}`)}>
+          {t(`${T_PATH}.cancel`)}
+        </Button>
+        <div className={styles.spacer} />
+        <Button
+          className={styles.cancelButton}
+          variant="secondary"
+          disabled={contractType === PermitContractType.FIXED_PERIOD && !iban}
+          onClick={() => {
+            endPermit({
+              variables: {
+                permitId: identifier,
+                endType: endType?.toUpperCase(),
+                iban:
+                  contractType === PermitContractType.FIXED_PERIOD
+                    ? iban
+                    : undefined,
+              },
+            }).then(() => navigate(`/permits/${id}`));
+          }}>
+          {t(`${T_PATH}.endPermit`)}
+        </Button>
+      </div>
+    </div>
+  );
+};
+export default makePrivate(EndPermit);

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -27,6 +27,7 @@ const PERMIT_DETAIL_QUERY = gql`
       startTime
       endTime
       currentPeriodEndTime
+      hasRefund
       status
       consentLowEmissionAccepted
       contractType

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -6,8 +6,6 @@ import { useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
-import StatusTag from '../components/common/StatusTag';
-import Zone from '../components/common/Zone';
 import CustomerInfo from '../components/permitDetail/CustomerInfo';
 import PermitInfo from '../components/permitDetail/PermitInfo';
 import RefundInfoFixedPeriod from '../components/permitDetail/RefundInfoFixedPeriod';
@@ -18,7 +16,6 @@ import {
   PermitContractType,
   PermitDetailData,
 } from '../types';
-import { formatCustomerName } from '../utils';
 import styles from './EndPermit.module.scss';
 
 const T_PATH = 'pages.endPermit';
@@ -100,24 +97,16 @@ const EndPermit = (): React.ReactElement => {
     return <div>No data</div>;
   }
   const { permitDetail } = data;
-  const { identifier, status, customer, parkingZone, contractType } =
-    permitDetail;
+  const { identifier, contractType } = permitDetail;
   return (
     <div className={styles.container}>
       <Breadcrumbs>
         <Link to="/permits">{t(`${T_PATH}.permits`)}</Link>
-        <span>{id}</span>
+        <Link to={`/permits/${id}`}>{id}</Link>
+        <span>{t(`${T_PATH}.endPermit`)}</span>
       </Breadcrumbs>
-      <div className={styles.status}>
-        <StatusTag status={status} />
-      </div>
       <div className={styles.header}>
-        <div className={styles.customer}>
-          <h2 className={styles.customerName}>
-            {formatCustomerName(customer)}
-          </h2>
-          <Zone name={parkingZone.name} />
-        </div>
+        <h2 className={styles.title}>{t(`${T_PATH}.title`)}</h2>
         <div className={styles.summary}>
           <b>{t(`${T_PATH}.residentParkingPermit`)}</b>{' '}
           <span>
@@ -149,6 +138,7 @@ const EndPermit = (): React.ReactElement => {
       <div className={styles.footer}>
         <Button
           className={styles.actionButton}
+          variant="secondary"
           iconLeft={<IconPenLine />}
           onClick={() => navigate(`/permits/${id}`)}>
           {t(`${T_PATH}.cancel`)}
@@ -156,7 +146,6 @@ const EndPermit = (): React.ReactElement => {
         <div className={styles.spacer} />
         <Button
           className={styles.cancelButton}
-          variant="secondary"
           disabled={contractType === PermitContractType.FIXED_PERIOD && !iban}
           onClick={() => {
             endPermit({

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -15,6 +15,7 @@ import {
   MutationResponse,
   PermitContractType,
   PermitDetailData,
+  PermitEndType,
 } from '../types';
 import styles from './EndPermit.module.scss';
 
@@ -98,7 +99,7 @@ const EndPermit = (): React.ReactElement => {
     return <div>No data</div>;
   }
   const { permitDetail } = data;
-  const { identifier, contractType } = permitDetail;
+  const { identifier, contractType, hasRefund } = permitDetail;
   return (
     <div className={styles.container}>
       <Breadcrumbs>
@@ -120,7 +121,13 @@ const EndPermit = (): React.ReactElement => {
           <VehicleInfo className={styles.vehicleInfo} permit={permitDetail} />
           <CustomerInfo className={styles.customerInfo} permit={permitDetail} />
         </div>
-        <PermitInfo className={styles.permitInfo} permit={permitDetail} />
+        <PermitInfo
+          className={styles.permitInfo}
+          endType={
+            endType ? (endType.toUpperCase() as PermitEndType) : undefined
+          }
+          permit={permitDetail}
+        />
         {contractType === PermitContractType.FIXED_PERIOD && (
           <RefundInfoFixedPeriod
             className={styles.refundInfo}
@@ -147,7 +154,11 @@ const EndPermit = (): React.ReactElement => {
         <div className={styles.spacer} />
         <Button
           className={styles.cancelButton}
-          disabled={contractType === PermitContractType.FIXED_PERIOD && !iban}
+          disabled={
+            contractType === PermitContractType.FIXED_PERIOD &&
+            !iban &&
+            !hasRefund
+          }
           onClick={() => {
             endPermit({
               variables: {

--- a/src/pages/PermitDetail.module.scss
+++ b/src/pages/PermitDetail.module.scss
@@ -20,6 +20,7 @@
   }
   .content {
     display: flex;
+    flex-direction: row;
     .vehicleInfo,
     .customerInfo {
       flex: 1 1 33%;
@@ -30,9 +31,26 @@
     }
   }
   .changeLogs {
-    margin: $spacing-xl 0;
+    margin-top: $spacing-xl;
+    margin-bottom: $spacing-5-xl;
     .changeLogsTitle {
       font-size: $fontsize-body-xl;
+    }
+  }
+  .footer {
+    padding: $spacing-m 0;
+    box-shadow: 0 -5px 5px -5px $color-black-30;
+    position: fixed;
+    width: 100%;
+    max-width: $breakpoint-xl;
+    left: calc(100% - $breakpoint-xl) / 2;
+    bottom: 0;
+    background-color: white;
+    display: flex;
+    flex-direction: row;
+
+    .spacer {
+      flex: 1 1 auto;
     }
   }
 }

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -26,6 +26,8 @@ const PERMIT_DETAIL_QUERY = gql`
       startTime
       endTime
       currentPeriodEndTime
+      canEndImmediately
+      canEndAfterCurrentPeriod
       status
       consentLowEmissionAccepted
       contractType
@@ -92,8 +94,15 @@ const PermitDetail = (): React.ReactElement => {
     return <div>No data</div>;
   }
   const { permitDetail } = data;
-  const { status, customer, parkingZone, changeLogs, currentPeriodEndTime } =
-    permitDetail;
+  const {
+    status,
+    customer,
+    parkingZone,
+    changeLogs,
+    currentPeriodEndTime,
+    canEndImmediately,
+    canEndAfterCurrentPeriod,
+  } = permitDetail;
   return (
     <div className={styles.container}>
       <Breadcrumbs>
@@ -139,6 +148,7 @@ const PermitDetail = (): React.ReactElement => {
         <Button
           className={styles.cancelButton}
           variant="secondary"
+          disabled={!canEndImmediately}
           onClick={() => setOpenEndPermitDialog(true)}>
           {t(`${T_PATH}.endPermit`)}
         </Button>
@@ -146,6 +156,7 @@ const PermitDetail = (): React.ReactElement => {
       <EndPermitDialog
         isOpen={openEndPermitDialog}
         currentPeriodEndTime={currentPeriodEndTime}
+        canEndAfterCurrentPeriod={canEndAfterCurrentPeriod}
         onCancel={() => setOpenEndPermitDialog(false)}
         onConfirm={(endType: PermitEndType) =>
           navigate(`end/${endType.toLowerCase()}`)

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,6 +5,7 @@ import AuthError from './pages/AuthError';
 import CreateCompanyPermit from './pages/CreateCompanyPermit';
 import CreatePermit from './pages/CreatePermit';
 import CreateResidentPermit from './pages/CreateResidentPermit';
+import EndPermit from './pages/EndPermit';
 import Login from './pages/Login';
 import Messages from './pages/Messages';
 import NotFound from './pages/NotFound';
@@ -21,6 +22,7 @@ const routes = [
       { path: 'login', element: <Login /> },
       { path: 'permits', element: <Permits /> },
       { path: 'permits/:id', element: <PermitDetail /> },
+      { path: 'permits/:id/end/:endType', element: <EndPermit /> },
       { path: 'permits/create', element: <CreatePermit /> },
       { path: 'permits/create/resident', element: <CreateResidentPermit /> },
       { path: 'permits/create/company', element: <CreateCompanyPermit /> },

--- a/src/services/mock.ts
+++ b/src/services/mock.ts
@@ -47,7 +47,7 @@ export function searchPerson(
       name: 'A',
       description: 'Kamppi',
       descriptionSv: 'Kampen',
-      price: 30,
+      residentPrice: 30,
     },
     addressSecurityBan: false,
     nationalIdNumber: personalId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface ParkingZone {
   name: string;
   description: string;
   descriptionSv: string;
-  price: number;
+  residentPrice: number;
 }
 
 export enum ParkingPermitStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface PermitDetail {
   currentPeriodEndTime: string;
   canEndImmediately: boolean;
   canEndAfterCurrentPeriod: boolean;
+  hasRefund: boolean;
   consentLowEmissionAccepted: boolean;
   contractType: PermitContractType;
   monthCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,8 @@ export interface PermitDetail {
   startTime: string;
   endTime?: string;
   currentPeriodEndTime: string;
+  canEndImmediately: boolean;
+  canEndAfterCurrentPeriod: boolean;
   consentLowEmissionAccepted: boolean;
   contractType: PermitContractType;
   monthCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export interface ResidentPermit extends FixedPeriodResidentPermit {
   vehicle: ResidentPermitVehicle;
 }
 
-export interface CreateResidentPermitResponse {
+export interface MutationResponse {
   success: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,10 +83,12 @@ export interface PermitDetail {
   status: ParkingPermitStatus;
   startTime: string;
   endTime?: string;
+  currentPeriodEndTime: string;
   consentLowEmissionAccepted: boolean;
   contractType: PermitContractType;
   monthCount: number;
   monthsLeft: number;
+  monthlyPrice: number;
   changeLogs: ChangeLog[];
 }
 
@@ -190,3 +192,8 @@ export enum SavedStatus {
 }
 
 export type Language = 'fi' | 'sv' | 'en';
+
+export enum PermitEndType {
+  IMMEDIATELY = 'IMMEDIATELY',
+  AFTER_CURRENT_PERIOD = 'AFTER_CURRENT_PERIOD',
+}


### PR DESCRIPTION
Admins can end permits from the permit detail page by clicking the end permit button if the permit can be ended.  If the permit cannot be ended, the button will be disabled.

Admins can choose from ending permit immediately or ending permit after the current period. For a fixed period permit, an IBAN is required for creating the refund. A permit that has been ended "after the current period" previously can still be ended immediately, but no need for IBAN input as the refund has already been created.




https://user-images.githubusercontent.com/1997039/142994111-2efe30f0-f149-4b77-a82e-65f78f0966da.mov


