### PR TITLE
Update time formatting

### DIFF
--- a/src/components/createResidentPermit/PermitInfo.tsx
+++ b/src/components/createResidentPermit/PermitInfo.tsx
@@ -1,4 +1,4 @@
-import { addMonths } from 'date-fns';
+import { addDays, addMonths, endOfDay } from 'date-fns';
 import { DateInput, NumberInput, TextArea, TextInput } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,11 +25,9 @@ const PermitInfo = ({
   onUpdateField,
 }: PermitInfoProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
-  const expirationDate = permit
-    ? formatDateTimeDisplay(
-        addMonths(new Date(permit.startTime), permit.monthCount)
-      )
-    : '';
+  const expirationDate = endOfDay(
+    addDays(addMonths(new Date(permit.startTime), permit.monthCount), -1)
+  );
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.permitInfo`)}</div>
@@ -84,7 +82,7 @@ const PermitInfo = ({
           className={styles.fieldItem}
           id="expirationDate"
           label={t(`${T_PATH}.expirationDate`)}
-          value={expirationDate}
+          value={formatDateTimeDisplay(expirationDate)}
         />
         <Divider className={styles.fieldDivider} />
         <TextArea

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,10 @@ export function formatDateDisplay(datetime: string | Date): string {
 export function formatDateTimeDisplay(datetime: string | Date): string {
   const dt = typeof datetime === 'string' ? new Date(datetime) : datetime;
   const dateStr = dt.toLocaleDateString('fi');
-  const timeStr = dt.toLocaleTimeString('fi');
+  const timeStr = dt.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
   return `${dateStr}, ${timeStr}`;
 }
 


### PR DESCRIPTION
Remove seconds and use international standard for time

This PR also fixes the end time calculation when creating resident permit.

Refs: PV-294