### PR TITLE
Remove holder from vehicle node query

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -38,8 +38,7 @@
         "personalID": "Personal ID",
         "phoneNumber": "Phone number",
         "sendMessageToEmail": "Send message to customer email",
-        "title": "Customer information",
-        "vehicleHolder": "Vehicle holder"
+        "title": "Customer information"
       },
       "endPermitDialog": {
         "cancel": "Cancel",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -38,8 +38,7 @@
         "personalID": "Henkilötunnus",
         "phoneNumber": "Puhelinnumero",
         "sendMessageToEmail": "Lähetä tiedot sähköpostiin",
-        "title": "Henkilötiedot",
-        "vehicleHolder": "Ajoneuvon haltija"
+        "title": "Henkilötiedot"
       },
       "endPermitDialog": {
         "cancel": "Peruuta",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -38,8 +38,7 @@
         "personalID": "Personligt ID",
         "phoneNumber": "Telefonnummer",
         "sendMessageToEmail": "Skicka meddelande till kundens e-post",
-        "title": "Kundinformation",
-        "vehicleHolder": "Fordonshållare"
+        "title": "Kundinformation"
       },
       "endPermitDialog": {
         "cancel": "Avbryt",

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -55,7 +55,6 @@ const PERMIT_DETAIL_QUERY = gql`
         model
         registrationNumber
         isLowEmission
-        holder
       }
       parkingZone {
         name


### PR DESCRIPTION
This is leftover from previous refactoring of resdent permit layout (where we remove the vehicle owner/holder selection)

no refs