### PR TITLE
Update refund interface and add refund list page

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,7 +29,7 @@ const Header = (): React.ReactElement => {
       label: t(`${T_PATH}.permits`),
     },
     {
-      path: '/returns',
+      path: '/refunds',
       label: t(`${T_PATH}.returns`),
     },
     {

--- a/src/components/permitDetail/RefundInfoFixedPeriod.tsx
+++ b/src/components/permitDetail/RefundInfoFixedPeriod.tsx
@@ -20,7 +20,7 @@ const RefundInfoFixedPeriod = ({
   onChangeIban,
 }: RefundInfoFixedPeriodProps): React.ReactElement => {
   const { t } = useTranslation();
-  const { monthsLeft, monthlyPrice, hasRefund } = permit;
+  const { monthsLeft, monthlyPrice, canBeRefunded } = permit;
   const refundAmount = `${(-monthsLeft * monthlyPrice).toFixed(2)} €`;
   const amountLabel = t(`${T_PATH}.monthCount`, {
     count: monthsLeft,
@@ -44,9 +44,7 @@ const RefundInfoFixedPeriod = ({
           <div className={styles.refundLabel}>{t(`${T_PATH}.refund`)}</div>
           <div className={styles.refundAmount}>{refundAmount}</div>
         </div>
-        {hasRefund ? (
-          <div className={styles.refunded}>{t(`${T_PATH}.refunded`)}</div>
-        ) : (
+        {canBeRefunded ? (
           <TextInput
             className={styles.iban}
             required
@@ -55,6 +53,8 @@ const RefundInfoFixedPeriod = ({
             value={iban}
             onChange={e => onChangeIban(e.target.value)}
           />
+        ) : (
+          <div className={styles.refunded}>{t(`${T_PATH}.refunded`)}</div>
         )}
       </div>
     </div>

--- a/src/components/refunds/RefundsDataTable.tsx
+++ b/src/components/refunds/RefundsDataTable.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { OrderBy, PageInfo, Refund } from '../../types';
+import { formatDateTimeDisplay } from '../../utils';
+import DataTable from '../common/DataTable';
+import { Column } from '../types';
+
+const T_PATH = 'components.refunds.refundsDataTable';
+
+export interface RefundsDataTableProps {
+  refunds: Refund[];
+  pageInfo?: PageInfo;
+  loading: boolean;
+  orderBy?: OrderBy;
+  onPage?: (page: number) => void;
+  onOrderBy: (orderBy: OrderBy) => void;
+  onRowClick?: (refund: Refund) => void;
+}
+
+const RefundsDataTable = ({
+  refunds,
+  pageInfo,
+  loading,
+  orderBy,
+  onPage,
+  onOrderBy,
+  onRowClick,
+}: RefundsDataTableProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const columns: Column<Refund>[] = [
+    {
+      name: t(`${T_PATH}.name`),
+      field: 'name',
+      selector: ({ name }) => name,
+      orderFields: ['name'],
+    },
+    {
+      name: t(`${T_PATH}.amount`),
+      field: 'amount',
+      selector: ({ amount }) => `${amount} €`,
+      orderFields: ['amount'],
+    },
+    {
+      name: 'IBAN',
+      field: 'iban',
+      selector: ({ iban }) => iban,
+      orderFields: ['iban'],
+    },
+    {
+      name: t(`${T_PATH}.status`),
+      field: 'status',
+      selector: ({ status }) => status,
+      orderFields: ['status'],
+    },
+    {
+      name: t(`${T_PATH}.createdAt`),
+      field: 'createdAt',
+      selector: ({ createdAt }) => formatDateTimeDisplay(createdAt),
+      orderFields: ['createdAt'],
+    },
+  ];
+
+  return (
+    <DataTable
+      data={refunds}
+      loading={loading}
+      pageInfo={pageInfo}
+      columns={columns}
+      orderBy={orderBy}
+      rowIdSelector={(refund: Refund) => refund.id}
+      onPage={onPage}
+      onOrderBy={onOrderBy}
+      onRowClick={onRowClick}
+    />
+  );
+};
+
+export default RefundsDataTable;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,6 +111,14 @@
         "status": "Status"
       }
     },
+    "refunds": {
+      "refundsDataTable": {
+        "amount": "Amount",
+        "createdAt": "Created at",
+        "name": "Name",
+        "status": "Status"
+      }
+    },
     "residentPermit": {
       "permitInfo": {
         "additionalInfo": "Additional information",
@@ -245,6 +253,9 @@
     "permits": {
       "createNewPermit": "Create new permit",
       "title": "Permits"
+    },
+    "refunds": {
+      "title": "Returns"
     },
     "superAdmin": {
       "createProduct": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -111,6 +111,14 @@
         "status": "Tila"
       }
     },
+    "refunds": {
+      "refundsDataTable": {
+        "amount": "Määrä",
+        "createdAt": "Muutosaika",
+        "name": "Nimi",
+        "status": "Tila"
+      }
+    },
     "residentPermit": {
       "permitInfo": {
         "additionalInfo": "Lisätiedot",
@@ -245,6 +253,9 @@
     "permits": {
       "createNewPermit": "Luo uusi tunnus",
       "title": "Tunnukset"
+    },
+    "refunds": {
+      "title": "Palautukset"
     },
     "superAdmin": {
       "createProduct": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -111,6 +111,14 @@
         "status": "Status"
       }
     },
+    "refunds": {
+      "refundsDataTable": {
+        "name": "Namn",
+        "amount": "Mängd",
+        "status": "Status",
+        "createdAt": "Skapade vid"
+      }
+    },
     "residentPermit": {
       "permitInfo": {
         "additionalInfo": "Ytterligare information",
@@ -245,6 +253,9 @@
     "permits": {
       "createNewPermit": "Skapa nytt tillstånd",
       "title": "Tillstånd"
+    },
+    "refunds": {
+      "title": "Returnerar"
     },
     "superAdmin": {
       "createProduct": {

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -30,6 +30,7 @@ const CUSTOMER_QUERY = gql`
       email
       phoneNumber
       zone
+      addressSecurityBan
       primaryAddress {
         city
         citySv
@@ -123,9 +124,11 @@ const CreateResidentPermit = (): React.ReactElement => {
   const handleCreateResidentPermit = () => {
     createResidentPermit({
       variables: { permit: convertToPermitInput(permit) },
-    }).then(() => {
-      navigate('/permits');
-    });
+    })
+      .then(() => {
+        navigate('/permits');
+      })
+      .catch(error => setErrorMessage(error.message));
   };
   const handleSearchVehicle = (regNumber: string) => {
     if (!customer.nationalIdNumber) {

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -28,7 +28,7 @@ const PERMIT_DETAIL_QUERY = gql`
       startTime
       endTime
       currentPeriodEndTime
-      hasRefund
+      canBeRefunded
       status
       consentLowEmissionAccepted
       contractType
@@ -98,7 +98,7 @@ const EndPermit = (): React.ReactElement => {
     return <div>loading...</div>;
   }
   const { permitDetail } = data;
-  const { identifier, contractType, hasRefund } = permitDetail;
+  const { identifier, contractType, canBeRefunded } = permitDetail;
   return (
     <div className={styles.container}>
       <Breadcrumbs>
@@ -156,7 +156,7 @@ const EndPermit = (): React.ReactElement => {
           disabled={
             contractType === PermitContractType.FIXED_PERIOD &&
             !iban &&
-            !hasRefund
+            !canBeRefunded
           }
           onClick={() => {
             endPermit({

--- a/src/pages/Refunds.module.scss
+++ b/src/pages/Refunds.module.scss
@@ -1,0 +1,5 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.container {
+  margin: $spacing-m;
+}

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -1,5 +1,80 @@
-import React from 'react';
+import { gql, useQuery } from '@apollo/client';
+import { Notification } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { makePrivate } from '../auth/utils';
+import RefundsDataTable from '../components/refunds/RefundsDataTable';
+import { OrderBy, RefundsQueryData } from '../types';
+import styles from './Permits.module.scss';
 
-const Refunds = (): React.ReactElement => <div>This is returns page</div>;
+const T_PATH = 'pages.refunds';
+
+const REFUNDS_QUERY = gql`
+  query GetRefunds($pageInput: PageInput!, $orderBy: OrderByInput) {
+    refunds(pageInput: $pageInput, orderBy: $orderBy) {
+      objects {
+        id
+        name
+        amount
+        iban
+        status
+        description
+        createdAt
+      }
+      pageInfo {
+        numPages
+        page
+        next
+        prev
+      }
+    }
+  }
+`;
+
+const Refunds = (): React.ReactElement => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [orderBy, setOrderBy] = useState<OrderBy | undefined>();
+  const [errorMessage, setErrorMessage] = useState('');
+  const variables = {
+    pageInput: { page },
+    orderBy,
+  };
+  const { loading, data } = useQuery<RefundsQueryData>(REFUNDS_QUERY, {
+    variables,
+    fetchPolicy: 'no-cache',
+    onError: error => setErrorMessage(error.message),
+  });
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>{t(`${T_PATH}.title`)}</h2>
+      <div className={styles.content}>
+        <RefundsDataTable
+          refunds={data?.refunds.objects || []}
+          pageInfo={data?.refunds.pageInfo}
+          loading={loading}
+          orderBy={orderBy}
+          onPage={newPage => setPage(newPage)}
+          onOrderBy={newOrderBy => setOrderBy(newOrderBy)}
+          onRowClick={refund => navigate(refund.id)}
+        />
+      </div>
+      {errorMessage && (
+        <Notification
+          type="error"
+          label={t('message.error')}
+          position="bottom-center"
+          dismissible
+          closeButtonLabelText={t('message.close')}
+          onClose={() => setErrorMessage('')}
+          style={{ zIndex: 100 }}>
+          {errorMessage}
+        </Notification>
+      )}
+    </div>
+  );
+};
+
 export default makePrivate(Refunds);

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { makePrivate } from '../auth/utils';
+
+const Refunds = (): React.ReactElement => <div>This is returns page</div>;
+export default makePrivate(Refunds);

--- a/src/pages/Returns.tsx
+++ b/src/pages/Returns.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-import { makePrivate } from '../auth/utils';
-
-const Returns = (): React.ReactElement => <div>This is returns page</div>;
-export default makePrivate(Returns);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,8 +13,8 @@ import Messages from './pages/Messages';
 import NotFound from './pages/NotFound';
 import PermitDetail from './pages/PermitDetail';
 import Permits from './pages/Permits';
+import Refunds from './pages/Refunds';
 import Reports from './pages/Reports';
-import Returns from './pages/Returns';
 import CreateProduct from './pages/superAdmin/CreateProduct';
 import EditProduct from './pages/superAdmin/EditProduct';
 import Products from './pages/superAdmin/Products';
@@ -42,7 +42,7 @@ const routes = [
       { path: 'permits/create', element: <CreatePermit /> },
       { path: 'permits/create/resident', element: <CreateResidentPermit /> },
       { path: 'permits/create/company', element: <CreateCompanyPermit /> },
-      { path: 'returns', element: <Returns /> },
+      { path: 'refunds', element: <Refunds /> },
       { path: 'messages', element: <Messages /> },
       { path: 'reports', element: <Reports /> },
       { path: 'authError', element: <AuthError /> },

--- a/src/services/addressSearch.ts
+++ b/src/services/addressSearch.ts
@@ -102,12 +102,18 @@ class AddressSearch {
 
   private async doSearch(searchText: string): Promise<AddressInput[]> {
     const searchUrl = this.buildSearchUrl(searchText);
-    const response = await fetch(searchUrl);
+    const response = await fetch(searchUrl).catch(() => null);
+    if (!response) {
+      return [];
+    }
     const data = (await response.json()) as { features: AddressWfsFeature[] };
     return data.features.map(feature => {
       const { coordinates } = feature.geometry;
       const entries = Object.entries(this.fieldMapping).map(
-        ([field, wfsField]) => [field, feature.properties[wfsField].toString()]
+        ([field, wfsField]) => {
+          const value = feature.properties[wfsField];
+          return [field, value ? value.toString() : ''];
+        }
       );
       return {
         sourceSystem: this.dataSource,

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export interface PermitDetail {
   currentPeriodEndTime: string;
   canEndImmediately: boolean;
   canEndAfterCurrentPeriod: boolean;
-  hasRefund: boolean;
+  canBeRefunded: boolean;
   consentLowEmissionAccepted: boolean;
   contractType: PermitContractType;
   monthCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,3 +270,23 @@ export enum PermitEndType {
   IMMEDIATELY = 'IMMEDIATELY',
   AFTER_CURRENT_PERIOD = 'AFTER_CURRENT_PERIOD',
 }
+
+export interface Refund {
+  id: string;
+  name: string;
+  amount: number;
+  iban: string;
+  status: string;
+  description: string;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface PagedRefunds {
+  objects: Refund[];
+  pageInfo: PageInfo;
+}
+
+export interface RefundsQueryData {
+  refunds: PagedRefunds;
+}


### PR DESCRIPTION
We have major refactoring on the refund calculation and related object interfaces. This PR updates the interfaces and also adds a refund list page.

Currently, refunds are only created when ending permits in Admin UI. The next step would be to create refunds for changing permits when the price of the permit goes down.

Related backend PR: 
https://github.com/City-of-Helsinki/parking-permits/pull/135

Refund list view:

![Screenshot 2022-01-29 at 12 04 11](https://user-images.githubusercontent.com/1997039/151656788-a9c74cee-459d-44e1-bca8-6018233f2ee2.png)


Refs: PV-232