### PR TITLE
Show a confirm payment dialog before permit is created

### DIFF
--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,47 @@
+import { Button, Dialog } from 'hds-react';
+import React from 'react';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  secondaryMessage?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const DIALOG_ID = 'confirm-dialog';
+const DIALOG_TITLE_ID = 'confirm-dialog-title';
+const DIALOG_DESCRIPTION_ID = 'confirm-dialog-description';
+
+const ConfirmDialog = ({
+  isOpen,
+  title,
+  message,
+  secondaryMessage,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): React.ReactElement => (
+  <Dialog
+    id={DIALOG_ID}
+    aria-labelledby={DIALOG_TITLE_ID}
+    aria-describedby={DIALOG_DESCRIPTION_ID}
+    isOpen={isOpen}>
+    <Dialog.Header id={DIALOG_TITLE_ID} title={title} />
+    <Dialog.Content>
+      <p id={DIALOG_DESCRIPTION_ID}>{message}</p>
+      {secondaryMessage && <p>{secondaryMessage}</p>}
+    </Dialog.Content>
+    <Dialog.ActionButtons>
+      <Button onClick={() => onConfirm()}>{confirmLabel}</Button>
+      <Button variant="secondary" onClick={() => onCancel()}>
+        {cancelLabel}
+      </Button>
+    </Dialog.ActionButtons>
+  </Dialog>
+);
+export default ConfirmDialog;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -215,6 +215,11 @@
     },
     "createResidentPermit": {
       "cancelAndCloseWithoutSaving": "Cancel and close without saving",
+      "cancelPayment": "Cancel payment",
+      "confirmPayment": "Payment completed",
+      "confirmPaymentMessage": "Before the permit becomes valid, the customer must make the payment.",
+      "confirmPaymentTitle": "Confirm Payment",
+      "confirmPaymentTotalAmount": "The total amount of the order is {{amount}} €.",
       "createNewPermit": "Create new permit",
       "monthCount_one": "{{count}} month",
       "monthCount_other": "{{count}} months",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -215,6 +215,11 @@
     },
     "createResidentPermit": {
       "cancelAndCloseWithoutSaving": "Peruuta ja sulje tallentamatta",
+      "cancelPayment": "Peruuta maksu",
+      "confirmPayment": "Maksu on suoritettu",
+      "confirmPaymentMessage": "Ennen tunnuksen voimaan asettamista, asiakkaan tulee suorittaa maksu.",
+      "confirmPaymentTitle": "Vahvista maksu",
+      "confirmPaymentTotalAmount": "Tilauksen kokonaissumma on {{amount}} €.",
       "createNewPermit": "Luo uusi tunnus",
       "monthCount_one": "{{count}} kuukausi",
       "monthCount_other": "{{count}} kuukautta",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -215,6 +215,11 @@
     },
     "createResidentPermit": {
       "cancelAndCloseWithoutSaving": "Avbryt och stäng utan att spara",
+      "cancelPayment": "Avbryt betalning",
+      "confirmPayment": "Betalning slutförd",
+      "confirmPaymentMessage": "Kunden måste göra en betalning innan ID:t kan träda i kraft.",
+      "confirmPaymentTitle": "Bekräfta betalning",
+      "confirmPaymentTotalAmount": "Det totala beloppet för beställningen är {{amount}} €.",
       "createNewPermit": "Skapa nytt tillstånd",
       "monthCount_one": "{{count}} månad",
       "monthCount_other": "{{count}} månader",

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,13 @@ export interface MutationResponse {
   success: boolean;
 }
 
+export interface CreatePermitResponse {
+  createResidentPermit: {
+    success: boolean;
+    permit: Pick<Permit, 'identifier'>;
+  };
+}
+
 export interface OrderBy {
   field: string;
   orderFields: string[];


### PR DESCRIPTION
- Show a confirmation dialog before permit is created
- Navigate to the permit detail page after the permit is created

![image](https://user-images.githubusercontent.com/1997039/154475805-4bd593cc-f82f-4f98-aee8-a056563c1716.png)

Refs: PV-338