### PR TITLE
Update resident permit refund: refund, extra payment and no price change cases

### DIFF
--- a/src/components/permitDetail/PermitPriceChangeInfo.module.scss
+++ b/src/components/permitDetail/PermitPriceChangeInfo.module.scss
@@ -1,0 +1,18 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.title {
+  font-size: $fontsize-body-xl;
+  margin-bottom: $spacing-s;
+}
+
+.infoBox {
+  padding: $spacing-s;
+  background-color: $color-silver-light;
+
+  .row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: $spacing-s;
+  }
+}

--- a/src/components/permitDetail/PermitPriceChangeInfo.tsx
+++ b/src/components/permitDetail/PermitPriceChangeInfo.tsx
@@ -48,7 +48,9 @@ const PriceChangeItem = ({
         </div>
       </div>
       <div className={styles.row}>
-        <div>{t(`${T_PATH}.priceChangeItemTotalLabel`)}</div>
+        <div>
+          {t(`${T_PATH}.priceChangeItemTotalLabel`, { count: monthCount })}
+        </div>
         <div>
           <b>{formatMonthlyPrice(newPrice * monthCount)}</b>
         </div>
@@ -133,6 +135,9 @@ const PermitPriceChangeInfo = ({
           <div className={styles.row}>
             <div>{t(`${T_PATH}.priceDifference`)}</div>
             <div>{priceChangeTotal} €</div>
+          </div>
+          <div className={styles.row}>
+            <div>{t(`${T_PATH}.priceCalcDescription`)}</div>
           </div>
         </div>
         {priceChangeType === PriceChangeType.HIGHER_PRICE && (

--- a/src/components/permitDetail/PermitPriceChangeInfo.tsx
+++ b/src/components/permitDetail/PermitPriceChangeInfo.tsx
@@ -1,0 +1,208 @@
+import { RadioButton, TextInput } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PermitPriceChange } from '../../types';
+import { formatDateDisplay, formatMonthlyPrice } from '../../utils';
+import Divider from '../common/Divider';
+import styles from './PermitPriceChangeInfo.module.scss';
+
+const T_PATH = 'components.permitDetail.permitPriceChangeInfo';
+
+enum PriceChangeType {
+  HIGHER_PRICE,
+  LOWER_PRICE,
+  NO_CHANGE,
+}
+
+interface PriceChangeItemProps {
+  className?: string;
+  type: PriceChangeType;
+  priceChangeItem: PermitPriceChange;
+}
+
+const PriceChangeItem = ({
+  className,
+  type,
+  priceChangeItem,
+}: PriceChangeItemProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const { product, newPrice, priceChange, startDate, endDate, monthCount } =
+    priceChangeItem;
+  const monthlyPriceLabel =
+    type === PriceChangeType.HIGHER_PRICE
+      ? `${formatMonthlyPrice(priceChange)} (${formatMonthlyPrice(newPrice)})`
+      : formatMonthlyPrice(newPrice);
+  return (
+    <div className={className}>
+      <div className={styles.row}>
+        <div>
+          <b>{product}</b>
+        </div>
+        <div>
+          <span>{monthlyPriceLabel}</span>
+        </div>
+      </div>
+      <div className={styles.row}>
+        <div>
+          {formatDateDisplay(startDate)} - {formatDateDisplay(endDate)}
+        </div>
+      </div>
+      <div className={styles.row}>
+        <div>{t(`${T_PATH}.priceChangeItemTotalLabel`)}</div>
+        <div>
+          <b>{formatMonthlyPrice(newPrice * monthCount)}</b>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+enum RefundAccountOption {
+  KNOWN = 'known',
+  UNKNOWN = 'unknown',
+}
+
+export interface PermitPriceChangeInfoProps {
+  className?: string;
+  priceChangeList: PermitPriceChange[];
+  refundAccountNumber: string;
+  onChangeRefundAccountNumber: (account: string) => void;
+}
+
+const PermitPriceChangeInfo = ({
+  className,
+  priceChangeList,
+  refundAccountNumber,
+  onChangeRefundAccountNumber,
+}: PermitPriceChangeInfoProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const [refundAccountOption, setRefundAccountOption] = useState(
+    RefundAccountOption.KNOWN
+  );
+  const newOrderTotal = priceChangeList.reduce(
+    (total, item) => total + item.newPrice * item.monthCount,
+    0
+  );
+  const previousOrderRemaining = priceChangeList.reduce(
+    (total, item) => total + item.previousPrice * item.monthCount,
+    0
+  );
+  const priceChangeTotal = priceChangeList.reduce(
+    (total, item) => total + item.priceChange * item.monthCount,
+    0
+  );
+  const priceChangeVatTotal = priceChangeList.reduce(
+    (total, item) => total + item.priceChangeVat * item.monthCount,
+    0
+  );
+  let priceChangeType = PriceChangeType.NO_CHANGE;
+  if (priceChangeTotal > 0) {
+    priceChangeType = PriceChangeType.HIGHER_PRICE;
+  } else if (priceChangeTotal < 0) {
+    priceChangeType = PriceChangeType.LOWER_PRICE;
+  } else {
+    priceChangeType = PriceChangeType.NO_CHANGE;
+  }
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+      <div className={styles.infoBox}>
+        <div className={styles.priceChanges}>
+          {priceChangeList.map((priceChange, index) => (
+            <>
+              <PriceChangeItem
+                key={`${priceChange.product}-${priceChange.startDate}`}
+                className={styles.priceChangeItem}
+                type={priceChangeType}
+                priceChangeItem={priceChange}
+              />
+              {index < priceChangeList.length - 1 && <Divider />}
+            </>
+          ))}
+        </div>
+        <div className={styles.totalInfo}>
+          <div className={styles.row}>
+            <div>{t(`${T_PATH}.newOrderTotal`)}</div>
+            <div>{newOrderTotal} €</div>
+          </div>
+          <div className={styles.row}>
+            <div>{t(`${T_PATH}.previousOrderRemaining`)}</div>
+            <div>{-previousOrderRemaining} €</div>
+          </div>
+          <Divider />
+          <div className={styles.row}>
+            <div>{t(`${T_PATH}.priceDifference`)}</div>
+            <div>{priceChangeTotal} €</div>
+          </div>
+        </div>
+        {priceChangeType === PriceChangeType.HIGHER_PRICE && (
+          <div className={styles.extraPayment}>
+            <div className={styles.row}>
+              <div>
+                <b>{t(`${T_PATH}.extraPaymentTotal`)}</b>
+              </div>
+              <div>
+                <b>{priceChangeTotal} €</b>
+              </div>
+            </div>
+            <div className={styles.row}>
+              <div>{t(`${T_PATH}.extraPaymentVatTotal`)}</div>
+              <div>{priceChangeVatTotal} €</div>
+            </div>
+          </div>
+        )}
+        {priceChangeType === PriceChangeType.LOWER_PRICE && (
+          <>
+            <div className={styles.refund}>
+              <div className={styles.row}>
+                <div>
+                  <b>{t(`${T_PATH}.refundTotal`)}</b>
+                </div>
+                <div>
+                  <b>{-priceChangeTotal} €</b>
+                </div>
+              </div>
+              <div className={styles.row}>
+                <div>{t(`${T_PATH}.refundTotalVat`)}</div>
+                <div>{-priceChangeVatTotal} €</div>
+              </div>
+            </div>
+            <div className={styles.ibanInfo}>
+              <RadioButton
+                id="customerAccountKnown"
+                name="accountNumberOption"
+                label={t(`${T_PATH}.customerAccountKnown`)}
+                value={RefundAccountOption.KNOWN}
+                checked={refundAccountOption === RefundAccountOption.KNOWN}
+                onChange={e =>
+                  setRefundAccountOption(e.target.value as RefundAccountOption)
+                }
+              />
+              <TextInput
+                className={styles.accountNumber}
+                required
+                id="iban"
+                label="IBAN"
+                disabled={refundAccountOption !== RefundAccountOption.KNOWN}
+                value={refundAccountNumber}
+                onChange={e => onChangeRefundAccountNumber(e.target.value)}
+              />
+              <RadioButton
+                id="customerAccountUnknown"
+                name="accountNumberOption"
+                label={t(`${T_PATH}.customerAccountUnknown`)}
+                value={RefundAccountOption.UNKNOWN}
+                checked={refundAccountOption === RefundAccountOption.UNKNOWN}
+                onChange={e => {
+                  setRefundAccountOption(e.target.value as RefundAccountOption);
+                  onChangeRefundAccountNumber('');
+                }}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+export default PermitPriceChangeInfo;

--- a/src/components/residentPermit/EditResidentPermitForm.module.scss
+++ b/src/components/residentPermit/EditResidentPermitForm.module.scss
@@ -1,0 +1,32 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.title {
+  font-weight: 600;
+  font-size: $fontsize-heading-xxs;
+  margin: $spacing-m 0;
+}
+
+.content {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: $spacing-5-xl;
+  .column {
+    flex: 1 1 33%;
+    &:not(:last-child) {
+      margin-right: $spacing-m;
+    }
+  }
+}
+
+.actions {
+  padding: $spacing-m 0;
+  box-shadow: 0 -5px 5px -5px $color-black-30;
+  position: fixed;
+  width: 100%;
+  max-width: $breakpoint-xl;
+  left: calc(100% - #{$breakpoint-xl}) / 2;
+  bottom: 0;
+  background-color: white;
+  display: flex;
+  flex-direction: row;
+}

--- a/src/components/residentPermit/EditResidentPermitForm.module.scss
+++ b/src/components/residentPermit/EditResidentPermitForm.module.scss
@@ -29,4 +29,5 @@
   background-color: white;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
 }

--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -1,0 +1,188 @@
+import { gql, useLazyQuery } from '@apollo/client';
+import { Button, IconCheckCircleFill } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Customer, PermitDetail, Vehicle } from '../../types';
+import styles from './EditResidentPermitForm.module.scss';
+import PermitInfo from './PermitInfo';
+import PersonalInfo from './PersonalInfo';
+import VehicleInfo from './VehicleInfo';
+
+const T_PATH = 'components.residentPermit.editResidentPermitForm';
+
+const CUSTOMER_QUERY = gql`
+  query GetCustomer($nationalIdNumber: String!) {
+    customer(nationalIdNumber: $nationalIdNumber) {
+      firstName
+      lastName
+      nationalIdNumber
+      email
+      phoneNumber
+      zone
+      primaryAddress {
+        city
+        citySv
+        streetName
+        streetNumber
+        postalCode
+        zone {
+          name
+          label
+          labelSv
+          residentProducts {
+            unitPrice
+            startDate
+            endDate
+            vat
+            lowEmissionDiscount
+            secondaryVehicleIncreaseRate
+          }
+        }
+      }
+    }
+  }
+`;
+
+const VEHICLE_QUERY = gql`
+  query GetVehicle($regNumber: String!, $nationalIdNumber: String!) {
+    vehicle(regNumber: $regNumber, nationalIdNumber: $nationalIdNumber) {
+      manufacturer
+      model
+      registrationNumber
+      isLowEmission
+      consentLowEmissionAccepted
+      serialNumber
+      category
+    }
+  }
+`;
+
+interface EditResidentPermitFormProps {
+  className?: string;
+  permit: PermitDetail;
+  onUpdatePermit: (permit: PermitDetail) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const EditResidentPermitForm = ({
+  className,
+  permit,
+  onUpdatePermit,
+  onCancel,
+  onConfirm,
+}: EditResidentPermitFormProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const [personSearchError, setPersonSearchError] = useState('');
+  const [vehicleSearchError, setVehicleSearchError] = useState('');
+  const { customer, vehicle } = permit;
+
+  const [getCustomer] = useLazyQuery<{
+    customer: Customer;
+  }>(CUSTOMER_QUERY, {
+    onCompleted: data => {
+      setPersonSearchError('');
+      onUpdatePermit({
+        ...permit,
+        customer: data.customer,
+      });
+    },
+    onError: error => setPersonSearchError(error.message),
+  });
+  const [getVehicle] = useLazyQuery<{
+    vehicle: Vehicle;
+  }>(VEHICLE_QUERY, {
+    onCompleted: data => {
+      setVehicleSearchError('');
+      onUpdatePermit({
+        ...permit,
+        vehicle: data.vehicle,
+      });
+    },
+    onError: error => setVehicleSearchError(error.message),
+  });
+
+  const handleSearchVehicle = (regNumber: string) => {
+    if (!customer.nationalIdNumber) {
+      return;
+    }
+    getVehicle({
+      variables: { regNumber, nationalIdNumber: customer.nationalIdNumber },
+    });
+  };
+
+  const handleSearchPerson = (nationalIdNumber: string) => {
+    getCustomer({
+      variables: { nationalIdNumber },
+    });
+  };
+
+  const handleUpdateVehicleField = (field: keyof Vehicle, value: unknown) => {
+    const newVehicle = {
+      ...vehicle,
+      [field]: value,
+    };
+    onUpdatePermit({
+      ...permit,
+      vehicle: newVehicle,
+    });
+  };
+  const handleUpdatePersonField = (field: keyof Customer, value: unknown) => {
+    const newCustomer = {
+      ...customer,
+      [field]: value,
+    };
+    onUpdatePermit({
+      ...permit,
+      customer: newCustomer,
+    });
+  };
+  const handleUpdatePermitField = (field: keyof PermitDetail, value: unknown) =>
+    onUpdatePermit({
+      ...permit,
+      [field]: value,
+    });
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+      <div className={styles.content}>
+        <PersonalInfo
+          className={styles.column}
+          person={customer}
+          searchError={personSearchError}
+          onSearchPerson={handleSearchPerson}
+          onUpdateField={handleUpdatePersonField}
+        />
+        <VehicleInfo
+          className={styles.column}
+          vehicle={vehicle}
+          zone={customer.zone}
+          searchError={vehicleSearchError}
+          onSearchRegistrationNumber={handleSearchVehicle}
+          onUpdateField={handleUpdateVehicleField}
+        />
+        <PermitInfo
+          className={styles.column}
+          editMode
+          permit={permit}
+          onUpdateField={handleUpdatePermitField}
+        />
+      </div>
+      <div className={styles.actions}>
+        <Button
+          className={styles.actionButton}
+          variant="secondary"
+          onClick={() => onCancel()}>
+          {t(`${T_PATH}.cancelAndCloseWithoutSaving`)}
+        </Button>
+        <Button
+          className={styles.actionButton}
+          iconLeft={<IconCheckCircleFill />}
+          onClick={() => onConfirm()}>
+          {t(`${T_PATH}.continue`)}
+        </Button>
+      </div>
+    </div>
+  );
+};
+export default EditResidentPermitForm;

--- a/src/components/residentPermit/EditResidentPermitPreview.module.scss
+++ b/src/components/residentPermit/EditResidentPermitPreview.module.scss
@@ -16,3 +16,17 @@
     }
   }
 }
+
+.actions {
+  padding: $spacing-m 0;
+  box-shadow: 0 -5px 5px -5px $color-black-30;
+  position: fixed;
+  width: 100%;
+  max-width: $breakpoint-xl;
+  left: calc(100% - #{$breakpoint-xl}) / 2;
+  bottom: 0;
+  background-color: white;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/src/components/residentPermit/EditResidentPermitPreview.module.scss
+++ b/src/components/residentPermit/EditResidentPermitPreview.module.scss
@@ -1,0 +1,18 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.title {
+  font-weight: 600;
+  font-size: $fontsize-heading-xxs;
+  margin: $spacing-m 0;
+}
+
+.content {
+  display: flex;
+  flex-direction: row;
+  .column {
+    flex: 1 1 33%;
+    &:not(:last-child) {
+      margin-right: $spacing-m;
+    }
+  }
+}

--- a/src/components/residentPermit/EditResidentPermitPreview.tsx
+++ b/src/components/residentPermit/EditResidentPermitPreview.tsx
@@ -61,7 +61,7 @@ const EditResidentPermitPreview = ({
           className={styles.actionButton}
           iconLeft={<IconCheckCircleFill />}
           onClick={() => onConfirm(refundAccountNumber)}>
-          {t(`${T_PATH}.continue`)}
+          {t(`${T_PATH}.save`)}
         </Button>
       </div>
     </div>

--- a/src/components/residentPermit/EditResidentPermitPreview.tsx
+++ b/src/components/residentPermit/EditResidentPermitPreview.tsx
@@ -1,5 +1,5 @@
 import { Button, IconCheckCircleFill } from 'hds-react';
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PermitDetail, PermitPriceChange } from '../../types';
 import CustomerInfo from '../permitDetail/CustomerInfo';
@@ -14,20 +14,22 @@ interface EditResidentPermitPreviewProps {
   className?: string;
   permit: PermitDetail;
   priceChangeList: PermitPriceChange[];
+  refundAccountNumber: string;
+  onChangeRefundAccountNumber: (accountNumber: string) => void;
   onCancel: () => void;
-  onConfirm: (refundAccountNumber: string) => void;
+  onConfirm: () => void;
 }
 
 const EditResidentPermitPreview = ({
   className,
   permit,
   priceChangeList,
+  refundAccountNumber,
+  onChangeRefundAccountNumber,
   onCancel,
   onConfirm,
 }: EditResidentPermitPreviewProps): React.ReactElement => {
   const { t } = useTranslation();
-  const [refundAccountNumber, setRefundAccountNumber] = useState('');
-
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
@@ -44,9 +46,7 @@ const EditResidentPermitPreview = ({
             className={styles.permitPriceChange}
             priceChangeList={priceChangeList}
             refundAccountNumber={refundAccountNumber}
-            onChangeRefundAccountNumber={accountNumber =>
-              setRefundAccountNumber(accountNumber)
-            }
+            onChangeRefundAccountNumber={onChangeRefundAccountNumber}
           />
         </div>
       </div>
@@ -60,7 +60,7 @@ const EditResidentPermitPreview = ({
         <Button
           className={styles.actionButton}
           iconLeft={<IconCheckCircleFill />}
-          onClick={() => onConfirm(refundAccountNumber)}>
+          onClick={() => onConfirm()}>
           {t(`${T_PATH}.save`)}
         </Button>
       </div>

--- a/src/components/residentPermit/EditResidentPermitPreview.tsx
+++ b/src/components/residentPermit/EditResidentPermitPreview.tsx
@@ -1,0 +1,70 @@
+import { Button, IconCheckCircleFill } from 'hds-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PermitDetail, PermitPriceChange } from '../../types';
+import CustomerInfo from '../permitDetail/CustomerInfo';
+import PermitInfo from '../permitDetail/PermitInfo';
+import PermitPriceChangeInfo from '../permitDetail/PermitPriceChangeInfo';
+import VehicleInfo from '../permitDetail/VehicleInfo';
+import styles from './EditResidentPermitPreview.module.scss';
+
+const T_PATH = 'components.residentPermit.editResidentPermitPreview';
+
+interface EditResidentPermitPreviewProps {
+  className?: string;
+  permit: PermitDetail;
+  priceChangeList: PermitPriceChange[];
+  onCancel: () => void;
+  onConfirm: (refundAccountNumber: string) => void;
+}
+
+const EditResidentPermitPreview = ({
+  className,
+  permit,
+  priceChangeList,
+  onCancel,
+  onConfirm,
+}: EditResidentPermitPreviewProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const [refundAccountNumber, setRefundAccountNumber] = useState('');
+
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+      <div className={styles.content}>
+        <div className={styles.column}>
+          <VehicleInfo className={styles.vehicleInfo} permit={permit} />
+          <CustomerInfo className={styles.customerInfo} permit={permit} />
+        </div>
+        <div className={styles.column}>
+          <PermitInfo className={styles.permitInfo} permit={permit} />
+        </div>
+        <div className={styles.column}>
+          <PermitPriceChangeInfo
+            className={styles.permitPriceChange}
+            priceChangeList={priceChangeList}
+            refundAccountNumber={refundAccountNumber}
+            onChangeRefundAccountNumber={accountNumber =>
+              setRefundAccountNumber(accountNumber)
+            }
+          />
+        </div>
+      </div>
+      <div className={styles.actions}>
+        <Button
+          className={styles.actionButton}
+          variant="secondary"
+          onClick={() => onCancel()}>
+          {t(`${T_PATH}.goBack`)}
+        </Button>
+        <Button
+          className={styles.actionButton}
+          iconLeft={<IconCheckCircleFill />}
+          onClick={() => onConfirm(refundAccountNumber)}>
+          {t(`${T_PATH}.continue`)}
+        </Button>
+      </div>
+    </div>
+  );
+};
+export default EditResidentPermitPreview;

--- a/src/components/residentPermit/PermitInfo.tsx
+++ b/src/components/residentPermit/PermitInfo.tsx
@@ -2,7 +2,7 @@ import { addDays, addMonths, endOfDay } from 'date-fns';
 import { DateInput, NumberInput, TextArea, TextInput } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { EditPermitDetail, Language } from '../../types';
+import { Language, PermitDetail } from '../../types';
 import { formatDateDisplay, formatDateTimeDisplay } from '../../utils';
 import Divider from '../common/Divider';
 import StatusSelect from '../permits/StatusSelect';
@@ -13,8 +13,8 @@ const T_PATH = 'components.residentPermit.permitInfo';
 interface PermitInfoProps {
   className?: string;
   editMode?: boolean;
-  permit: EditPermitDetail;
-  onUpdateField: (field: keyof EditPermitDetail, value: unknown) => void;
+  permit: PermitDetail;
+  onUpdateField: (field: keyof PermitDetail, value: unknown) => void;
 }
 
 const PermitInfo = ({

--- a/src/components/residentPermit/consts.ts
+++ b/src/components/residentPermit/consts.ts
@@ -1,8 +1,10 @@
+import { addDays, addMonths, endOfDay } from 'date-fns';
 import {
   Customer,
-  EditPermitDetail,
   ParkingPermitStatus,
+  ParkingZone,
   PermitContractType,
+  PermitDetail,
   Vehicle,
 } from '../../types';
 
@@ -26,11 +28,31 @@ export const initialVehicle: Vehicle = {
   category: 'M1',
 };
 
-export const initialPermit: EditPermitDetail = {
-  contractType: PermitContractType.FIXED_PERIOD,
-  monthCount: 1,
-  startTime: new Date().toISOString(),
-  status: ParkingPermitStatus.VALID,
-  vehicle: initialVehicle,
-  customer: initialPerson,
+export const initialParkingZone: ParkingZone = {
+  name: '',
+  label: '',
+  labelSv: '',
 };
+
+export function getEmptyPermit(): PermitDetail {
+  const startTime = new Date();
+  const endTime = endOfDay(addDays(addMonths(new Date(startTime), 1), -1));
+  return {
+    customer: initialPerson,
+    vehicle: initialVehicle,
+    parkingZone: initialParkingZone,
+    status: ParkingPermitStatus.VALID,
+    startTime: startTime.toISOString(),
+    endTime: endTime.toISOString(),
+    currentPeriodEndTime: '',
+    canEndImmediately: false,
+    canEndAfterCurrentPeriod: false,
+    canBeRefunded: false,
+    consentLowEmissionAccepted: false,
+    contractType: PermitContractType.FIXED_PERIOD,
+    monthCount: 1,
+    monthsLeft: 0,
+    monthlyPrice: 0,
+    changeLogs: [],
+  };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -67,6 +67,20 @@
         "title": "Permit information",
         "validPeriod": "Valid period"
       },
+      "permitPriceChangeInfo": {
+        "customerAccountKnown": "Customer account number for refund",
+        "customerAccountUnknown": "Customer account number unknown",
+        "extraPaymentTotal": "Total additional payment",
+        "extraPaymentVatTotal": "Incl. VAT (24%)",
+        "newOrderTotal": "New order, total price",
+        "previousOrderRemaining": "Previous order, total price",
+        "priceCalcDescription": "Prices take into account the remaining full months of the order.",
+        "priceChangeItemTotalLabel": "{{count}} months total (incl. VAT 24%)",
+        "priceDifference": "PriceDifference",
+        "refundTotal": "Total amount to be refunded",
+        "refundTotalVat": "Incl. VAT (24%)",
+        "title": "New Order"
+      },
       "refundInfoFixedPeriod": {
         "monthCount_one": "{{count}} month",
         "monthCount_other": "{{count}} months",
@@ -123,6 +137,16 @@
       }
     },
     "residentPermit": {
+      "editResidentPermitForm": {
+        "cancelAndCloseWithoutSaving": "Cancel and close without saving",
+        "continue": "Continue",
+        "title": "Resident parking permit"
+      },
+      "editResidentPermitPreview": {
+        "title": "Summary",
+        "goBack": "Go back",
+        "save": "Save"
+      },
       "permitInfo": {
         "additionalInfo": "Additional information",
         "additionalInfoPlaceholder": "Additional information, e.g. information about moped",
@@ -231,12 +255,11 @@
       "save": "Save",
       "totalPrice": "Total price"
     },
-    "editPermit": {
-      "cancelAndCloseWithoutSaving": "Cancel and close without saving",
+    "editResidentPermit": {
       "edit": "Edit",
+      "loading": "Loading...",
       "permits": "Permits",
-      "save": "Save",
-      "title": "Resident parking permit"
+      "save": "Save"
     },
     "endPermit": {
       "cancel": "Cancel",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -143,9 +143,9 @@
         "title": "Resident parking permit"
       },
       "editResidentPermitPreview": {
-        "title": "Summary",
         "goBack": "Go back",
-        "save": "Save"
+        "save": "Save",
+        "title": "Summary"
       },
       "permitInfo": {
         "additionalInfo": "Additional information",
@@ -256,6 +256,11 @@
       "totalPrice": "Total price"
     },
     "editResidentPermit": {
+      "cancelPayment": "Cancel payment",
+      "confirmPayment": "Payment completed",
+      "confirmPaymentMessage": "Before the permit becomes valid, the customer must make the payment.",
+      "confirmPaymentTitle": "Confirm Payment",
+      "confirmPaymentTotalAmount": "The total amount of the order is {{amount}} €.",
       "edit": "Edit",
       "loading": "Loading...",
       "permits": "Permits",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -66,6 +66,20 @@
         "title": "Tunnuksen tiedot",
         "validPeriod": "Voimassaoloaika"
       },
+      "permitPriceChangeInfo": {
+        "customerAccountKnown": "Asiakkaan tilinumero hyvitystä varten",
+        "customerAccountUnknown": "Asiakkaan tilinumero ei tiedossa",
+        "extraPaymentTotal": "Lisäveloitus yhteensä",
+        "extraPaymentVatTotal": "Sis. alv (24%)",
+        "newOrderTotal": "Uusi tilaus, kokonaishinta",
+        "previousOrderRemaining": "Edellinen tilaus, kokonaishinta",
+        "priceCalcDescription": "Hinnoissa huomioidaan tilauksen jäljellä olevat täydet kuukaudet.",
+        "priceChangeItemTotalLabel": "{{count}} kk yhteensä (sis. alv 24%)",
+        "priceDifference": "Hintaero",
+        "refundTotal": "Palautettava summa yhteensä",
+        "refundTotalVat": "Sis. alv (24%)",
+        "title": "Uusi tilaus"
+      },
       "refundInfoFixedPeriod": {
         "monthCount_one": "{{count}} kuukausi",
         "monthCount_other": "{{count}} kuukautta",
@@ -123,6 +137,16 @@
       }
     },
     "residentPermit": {
+      "editResidentPermitForm": {
+        "cancelAndCloseWithoutSaving": "Peruuta ja sulje tallentamatta",
+        "continue": "Jatkaa",
+        "title": "Asukaspysäköintitunnus"
+      },
+      "editResidentPermitPreview": {
+        "goBack": "Edellinen",
+        "save": "Tallenna",
+        "title": "Yhteenveto"
+      },
       "permitInfo": {
         "additionalInfo": "Lisätiedot",
         "additionalInfoPlaceholder": "Lisätietoihin esim. tieto mopoautosta",
@@ -231,12 +255,11 @@
       "save": "Tallenna",
       "totalPrice": "Tunnuksen yhteissumma"
     },
-    "editPermit": {
-      "cancelAndCloseWithoutSaving": "Peruuta ja sulje tallentamatta",
+    "editResidentPermit": {
       "edit": "Muokkaustilassa",
+      "loading": "Ladataan...",
       "permits": "Tunnukset",
-      "save": "Tallenna",
-      "title": "Asukaspysäköintitunnus"
+      "save": "Tallenna"
     },
     "endPermit": {
       "cancel": "Peruuta",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -256,6 +256,11 @@
       "totalPrice": "Tunnuksen yhteissumma"
     },
     "editResidentPermit": {
+      "cancelPayment": "Peruuta maksu",
+      "confirmPayment": "Maksu on suoritettu",
+      "confirmPaymentMessage": "Ennen tunnuksen voimaan asettamista, asiakkaan tulee suorittaa maksu.",
+      "confirmPaymentTitle": "Vahvista maksu",
+      "confirmPaymentTotalAmount": "Tilauksen kokonaissumma on {{amount}} €.",
       "edit": "Muokkaustilassa",
       "loading": "Ladataan...",
       "permits": "Tunnukset",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -143,9 +143,9 @@
         "title": "Parkeringstillstånd för boende"
       },
       "editResidentPermitPreview": {
-        "title": "Sammanfattning",
         "goBack": "Föregående",
-        "save": "Spara"
+        "save": "Spara",
+        "title": "Sammanfattning"
       },
       "permitInfo": {
         "additionalInfo": "Ytterligare information",
@@ -256,6 +256,11 @@
       "totalPrice": "Totalpris"
     },
     "editResidentPermit": {
+      "cancelPayment": "Avbryt betalning",
+      "confirmPayment": "Betalning slutförd",
+      "confirmPaymentMessage": "Kunden måste göra en betalning innan ID:t kan träda i kraft.",
+      "confirmPaymentTitle": "Bekräfta betalning",
+      "confirmPaymentTotalAmount": "Det totala beloppet för beställningen är {{amount}} €.",
       "edit": "Redigera",
       "loading": "Läser in...",
       "permits": "Tillstånd",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -66,6 +66,20 @@
         "title": "Tillståndsinformation",
         "validPeriod": "Giltig period"
       },
+      "permitPriceChangeInfo": {
+        "customerAccountKnown": "Kundkontonummer för återbetalning",
+        "customerAccountUnknown": "Kundkontonummer okänt",
+        "extraPaymentTotal": "Total extra kostnad",
+        "extraPaymentVatTotal": "Inkl. moms (24%)",
+        "newOrderTotal": "Ny order, totalpris",
+        "previousOrderRemaining": "föregående beställning, totalpris",
+        "priceCalcDescription": "Priserna tar hänsyn till de återstående hela månaderna av beställningen.",
+        "priceChangeItemTotalLabel": "{{count}} månader totalt (inkl. moms 24%)",
+        "priceDifference": "PriceDifference",
+        "refundTotal": "Totalt belopp som ska återbetalas",
+        "refundTotalVat": "Inkl. moms (24%)",
+        "title": "Ny prenumeration"
+      },
       "refundInfoFixedPeriod": {
         "monthCount_one": "{{count}} månad",
         "monthCount_other": "{{count}} månader",
@@ -123,6 +137,16 @@
       }
     },
     "residentPermit": {
+      "editResidentPermitForm": {
+        "cancelAndCloseWithoutSaving": "Avbryt och stäng utan att spara",
+        "continue": "Fortsätta",
+        "title": "Parkeringstillstånd för boende"
+      },
+      "editResidentPermitPreview": {
+        "title": "Sammanfattning",
+        "goBack": "Föregående",
+        "save": "Spara"
+      },
       "permitInfo": {
         "additionalInfo": "Ytterligare information",
         "additionalInfoPlaceholder": "För ytterligare information, t.ex. information om mopeden",
@@ -231,12 +255,11 @@
       "save": "Spara",
       "totalPrice": "Totalpris"
     },
-    "editPermit": {
-      "cancelAndCloseWithoutSaving": "Avbryt och stäng utan att spara",
+    "editResidentPermit": {
       "edit": "Redigera",
+      "loading": "Läser in...",
       "permits": "Tillstånd",
-      "save": "Spara",
-      "title": "Parkeringstillstånd för boende"
+      "save": "Spara"
     },
     "endPermit": {
       "cancel": "Avbryt",

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -6,14 +6,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { initialPermit } from '../components/residentPermit/consts';
+import { getEmptyPermit } from '../components/residentPermit/consts';
 import PermitInfo from '../components/residentPermit/PermitInfo';
 import PersonalInfo from '../components/residentPermit/PersonalInfo';
 import VehicleInfo from '../components/residentPermit/VehicleInfo';
 import {
   CreatePermitResponse,
   Customer,
-  EditPermitDetail,
   PermitDetail,
   Vehicle,
 } from '../types';
@@ -85,7 +84,8 @@ const CreateResidentPermit = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   // states
-  const [permit, setPermit] = useState<EditPermitDetail>(initialPermit);
+  const initialPermit = getEmptyPermit();
+  const [permit, setPermit] = useState<PermitDetail>(initialPermit);
   const [personSearchError, setPersonSearchError] = useState('');
   const [vehicleSearchError, setVehicleSearchError] = useState('');
   const [errorMessage, setErrorMessage] = useState('');

--- a/src/pages/EditResidentPermit.module.scss
+++ b/src/pages/EditResidentPermit.module.scss
@@ -26,17 +26,4 @@
       margin-right: $spacing-m;
     }
   }
-  .footer {
-    padding: $spacing-m 0;
-    box-shadow: 0 -5px 5px -5px $color-black-30;
-    position: fixed;
-    width: 100%;
-    max-width: $breakpoint-xl;
-    left: calc(100% - #{$breakpoint-xl}) / 2;
-    bottom: 0;
-    background-color: white;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
 }

--- a/src/pages/EndPermit.module.scss
+++ b/src/pages/EndPermit.module.scss
@@ -18,40 +18,4 @@
       }
     }
   }
-  .content {
-    display: flex;
-    flex-direction: row;
-    margin-bottom: $spacing-5-xl;
-    .vehicleAndPerson {
-      flex: 1 1 33%;
-      margin-right: $spacing-m;
-      .vehicleInfo,
-      .customerInfo {
-        margin-bottom: $spacing-l;
-      }
-    }
-    .permitInfo {
-      flex: 1 1 33%;
-      margin-right: $spacing-m;
-    }
-    .refundInfo {
-      flex: 1 1 33%;
-    }
-  }
-  .footer {
-    padding: $spacing-m 0;
-    box-shadow: 0 -5px 5px -5px $color-black-30;
-    position: fixed;
-    width: 100%;
-    max-width: $breakpoint-xl;
-    left: calc(100% - #{$breakpoint-xl}) / 2;
-    bottom: 0;
-    background-color: white;
-    display: flex;
-    flex-direction: row;
-
-    .spacer {
-      flex: 1 1 auto;
-    }
-  }
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,7 +6,7 @@ import AuthError from './pages/AuthError';
 import CreateCompanyPermit from './pages/CreateCompanyPermit';
 import CreatePermit from './pages/CreatePermit';
 import CreateResidentPermit from './pages/CreateResidentPermit';
-import EditPermit from './pages/EditResidentPermit';
+import EditResidentPermit from './pages/EditResidentPermit';
 import EndPermit from './pages/EndPermit';
 import Login from './pages/Login';
 import Messages from './pages/Messages';
@@ -39,7 +39,7 @@ const routes = [
       { path: 'permits', element: <Permits /> },
       { path: 'permits/:id', element: <PermitDetail /> },
       { path: 'permits/:id/end/:endType', element: <EndPermit /> },
-      { path: 'permits/:id/edit/', element: <EditPermit /> },
+      { path: 'permits/:id/edit/', element: <EditResidentPermit /> },
       { path: 'permits/create', element: <CreatePermit /> },
       { path: 'permits/create/resident', element: <CreateResidentPermit /> },
       { path: 'permits/create/company', element: <CreateCompanyPermit /> },

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface ChangeLog {
 }
 
 export interface PermitDetail {
-  identifier: number;
+  identifier?: number;
   customer: Customer;
   vehicle: Vehicle;
   parkingZone: ParkingZone;
@@ -148,17 +148,6 @@ export interface PermitDetail {
   monthlyPrice: number;
   changeLogs: ChangeLog[];
 }
-
-export type EditPermitDetail = Pick<
-  PermitDetail,
-  | 'contractType'
-  | 'monthCount'
-  | 'startTime'
-  | 'endTime'
-  | 'status'
-  | 'vehicle'
-  | 'customer'
->;
 
 export interface PermitDetailData {
   permitDetail: PermitDetail;
@@ -306,4 +295,15 @@ export interface RefundsQueryData {
 export interface RefundInput {
   name: string;
   iban: string;
+}
+
+export interface PermitPriceChange {
+  product: string;
+  previousPrice: number;
+  newPrice: number;
+  priceChange: number;
+  priceChangeVat: number;
+  startDate: string;
+  endDate: string;
+  monthCount: number;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   AddressInput,
   Customer,
   CustomerInput,
-  EditPermitDetail,
+  PermitDetail,
   PermitInput,
   PriceModifiers,
   Product,
@@ -131,7 +131,7 @@ export function convertToCustomerInput(customer: Customer): CustomerInput {
   };
 }
 
-export function convertToPermitInput(permit: EditPermitDetail): PermitInput {
+export function convertToPermitInput(permit: PermitDetail): PermitInput {
   const { contractType, customer, vehicle, status, startTime, monthCount } =
     permit;
   const vehicleInput = convertToVehicleInput(vehicle);


### PR DESCRIPTION
This PR implements three different cases when the admin updating the resident permit:

1. if the price of the permit does not change, it displays the change preview and price info
2. if the price of the permit goes up, it displays the change preview and on extra payment needed. The admin can confirm new order after the customer's payment is confirmed
3. if the price of the permit goes down, it displays the change preview and refund amount. The admin can optionally enter a IBAN provided by the customer. After the admin confirms the refund, a refund will be created.

Refs: PV-337

https://user-images.githubusercontent.com/1997039/155979527-1982f6f8-5088-4210-b1be-65c9e80f05cb.mov


