### PR TITLE
Disable the number input and date input when editing permits

### DIFF
--- a/src/components/residentPermit/PermitInfo.tsx
+++ b/src/components/residentPermit/PermitInfo.tsx
@@ -41,7 +41,7 @@ const PermitInfo = ({
         />
         <NumberInput
           required
-          readOnly={editMode}
+          disabled={editMode}
           className={styles.fieldItem}
           id="validPeriodInMonths"
           label={t(`${T_PATH}.validPeriodInMonths`)}
@@ -55,7 +55,7 @@ const PermitInfo = ({
         />
         <DateInput
           required
-          readOnly={editMode}
+          disabled={editMode}
           className={styles.fieldItem}
           id="startDate"
           initialMonth={new Date()}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -139,7 +139,7 @@
     "residentPermit": {
       "editResidentPermitForm": {
         "cancelAndCloseWithoutSaving": "Peruuta ja sulje tallentamatta",
-        "continue": "Jatkaa",
+        "continue": "Jatka",
         "title": "Asukaspysäköintitunnus"
       },
       "editResidentPermitPreview": {


### PR DESCRIPTION
Set the fields to read only doesn't prevent changing the value through
widget buttons

Refs: PV-373

![image](https://user-images.githubusercontent.com/1997039/156181755-d1f650db-bc2f-49bc-b91c-65b3f78da9e4.png)
