### PR TITLE
Improve address UI

### DIFF
--- a/src/components/common/AddressSearch.tsx
+++ b/src/components/common/AddressSearch.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  IconArrowLeft,
-  IconPen,
-  SearchInput,
-  TextInput,
-} from 'hds-react';
-import React, { useState } from 'react';
+import { SearchInput, TextInput } from 'hds-react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import addressSearch from '../../services/addressSearch';
 import { Address, AddressInput } from '../../types';
@@ -16,7 +10,7 @@ const T_PATH = 'components.common.addressSearch';
 interface AddressSearchProps {
   className?: string;
   disabled?: boolean;
-  label: string;
+  label?: string;
   address?: Address;
   errorText?: string;
   onSelect: (address: AddressInput) => void;
@@ -36,7 +30,6 @@ const AddressSearch = ({
   onSelect,
 }: AddressSearchProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
-  const [isEditing, setIsEditing] = useState(false);
   let searchSuggestions: AddressSuggestionItem[] = [];
   const getSuggestions = (inputValue: string) =>
     addressSearch.search(inputValue).then(addresses => {
@@ -53,52 +46,33 @@ const AddressSearch = ({
     );
     if (item) {
       onSelect(item.address);
-      setIsEditing(false);
     }
   };
 
-  if (isEditing && !disabled) {
+  if (!disabled) {
     return (
-      <>
-        <SearchInput
-          hideSearchButton
-          className={className}
-          label={label}
-          clearButtonAriaLabel={t(`${T_PATH}.clear`)}
-          suggestionLabelField="label"
-          getSuggestions={getSuggestions}
-          onSubmit={handleSubmit}
-        />
-        <Button
-          variant="supplementary"
-          size="small"
-          iconLeft={<IconArrowLeft />}
-          onClick={() => setIsEditing(false)}>
-          {t(`${T_PATH}.cancel`)}
-        </Button>
-      </>
+      <SearchInput
+        hideSearchButton
+        className={className}
+        label={label}
+        clearButtonAriaLabel={t(`${T_PATH}.clear`)}
+        suggestionLabelField="label"
+        getSuggestions={getSuggestions}
+        onSubmit={handleSubmit}
+      />
     );
   }
+  // HDS SearchInput does not have a disabled property,
+  // so use a TextInput for disabled
   return (
-    <>
-      <TextInput
-        readOnly
-        className={className}
-        id="address"
-        label={label}
-        value={address ? formatAddress(address, i18n.language) : '-'}
-        errorText={errorText}
-      />
-      {!disabled && (
-        <Button
-          variant="supplementary"
-          size="small"
-          iconLeft={<IconPen />}
-          onClick={() => setIsEditing(true)}>
-          {t(`${T_PATH}.edit`)}
-        </Button>
-      )}
-    </>
+    <TextInput
+      disabled
+      className={className}
+      id="address"
+      label={label}
+      value={address ? formatAddress(address, i18n.language) : ''}
+      errorText={errorText}
+    />
   );
 };
 

--- a/src/components/common/AddressSearch.tsx
+++ b/src/components/common/AddressSearch.tsx
@@ -55,6 +55,7 @@ const AddressSearch = ({
         hideSearchButton
         className={className}
         label={label}
+        placeholder={address ? formatAddress(address, i18n.language) : ''}
         clearButtonAriaLabel={t(`${T_PATH}.clear`)}
         suggestionLabelField="label"
         getSuggestions={getSuggestions}

--- a/src/components/permitDetail/CustomerInfo.tsx
+++ b/src/components/permitDetail/CustomerInfo.tsx
@@ -25,9 +25,15 @@ const CustomerInfo = ({
       value: customer.nationalIdNumber || '-',
     },
     {
-      label: t(`${T_PATH}.address`),
+      label: t(`${T_PATH}.primaryAddress`),
       value: customer?.primaryAddress
         ? formatAddress(customer.primaryAddress, i18n.language)
+        : '-',
+    },
+    {
+      label: t(`${T_PATH}.otherAddress`),
+      value: customer?.otherAddress
+        ? formatAddress(customer.otherAddress, i18n.language)
         : '-',
     },
     {

--- a/src/components/permits/PermitsDataTable.tsx
+++ b/src/components/permits/PermitsDataTable.tsx
@@ -52,8 +52,8 @@ const PermitsDataTable = ({
       orderFields: ['vehicle__registration_number'],
     },
     {
-      name: t(`${T_PATH}.address`),
-      field: 'address',
+      name: t(`${T_PATH}.primaryAddress`),
+      field: 'primaryAddress',
       selector: ({ customer }) =>
         customer?.primaryAddress
           ? formatAddress(customer.primaryAddress, i18n.language)
@@ -61,6 +61,18 @@ const PermitsDataTable = ({
       orderFields: [
         'customer__primary_address__street_name',
         'customer__primary_address__street_number',
+      ],
+    },
+    {
+      name: t(`${T_PATH}.otherAddress`),
+      field: 'otherAddress',
+      selector: ({ customer }) =>
+        customer?.otherAddress
+          ? formatAddress(customer.otherAddress, i18n.language)
+          : '-',
+      orderFields: [
+        'customer__other_address__street_name',
+        'customer__other_address__street_number',
       ],
     },
     {

--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -39,6 +39,26 @@ const CUSTOMER_QUERY = gql`
           }
         }
       }
+      otherAddress {
+        city
+        citySv
+        streetName
+        streetNumber
+        postalCode
+        zone {
+          name
+          label
+          labelSv
+          residentProducts {
+            unitPrice
+            startDate
+            endDate
+            vat
+            lowEmissionDiscount
+            secondaryVehicleIncreaseRate
+          }
+        }
+      }
     }
   }
 `;

--- a/src/components/residentPermit/PersonalInfo.module.scss
+++ b/src/components/residentPermit/PersonalInfo.module.scss
@@ -10,6 +10,11 @@
   flex-direction: column;
   padding: $spacing-s;
 
+  .addressSearch {
+    margin-left: $spacing-l;
+    margin-bottom: $spacing-s;
+  }
+
   .fieldItem {
     margin: $spacing-2-xs 0;
   }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,7 +40,8 @@
     },
     "permitDetail": {
       "customerInfo": {
-        "address": "Address",
+        "primaryAddress": "Permanent address",
+        "otherAddress": "Temporary address",
         "email": "Email",
         "parkingZone": "Parking zone",
         "personalID": "Personal ID",
@@ -109,7 +110,8 @@
         "registrationNumber": "Registration number"
       },
       "permitsDataTable": {
-        "address": "Address",
+        "primaryAddress": "Permanent address",
+        "otherAddress": "Temporary address",
         "endTime": "End time",
         "name": "Name",
         "registrationNumber": "Registration number",
@@ -159,7 +161,8 @@
         "validPeriodInMonths": "Valid period in months"
       },
       "personalInfo": {
-        "address": "Address",
+        "primaryAddress": "Permanent address",
+        "otherAddress": "Temporary address",
         "addressSecurityBan": "Non-disclosure for personal safety",
         "driverLicenseChecked": "Driver's licese is checked",
         "email": "Email",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -40,11 +40,12 @@
     },
     "permitDetail": {
       "customerInfo": {
-        "address": "Osoite",
         "email": "Sähköpostiosoite",
+        "otherAddress": "Tilapäinen osoite",
         "parkingZone": "Pysäköintialue",
         "personalID": "Henkilötunnus",
         "phoneNumber": "Puhelinnumero",
+        "primaryAddress": "Vakituinen osoite",
         "sendMessageToEmail": "Lähetä tiedot sähköpostiin",
         "title": "Henkilötiedot"
       },
@@ -110,9 +111,10 @@
         "registrationNumber": "Rekisterinumero"
       },
       "permitsDataTable": {
-        "address": "Osoite",
         "endTime": "Loppuaika",
         "name": "Nimi",
+        "otherAddress": "Tilapäinen osoite",
+        "primaryAddress": "Vakituinen osoite",
         "registrationNumber": "Rekisterinumero",
         "startTime": "Alkuaika",
         "status": "Tila",
@@ -160,15 +162,16 @@
         "validPeriodInMonths": "Voimassaoloaika, kuukautta"
       },
       "personalInfo": {
-        "address": "Osoite",
         "addressSecurityBan": "Turvakielto: Osoitetta ja nimeä ei kirjata",
         "driverLicenseChecked": "Asiakkaan ajokortti tarkistettu",
         "email": "Sähköpostiosoite",
         "firstName": "Etunimi",
         "lastName": "Sukunimi",
+        "otherAddress": "Tilapäinen osoite",
         "personalId": "Henkilötunnus",
         "personalInfo": "Henkilötiedot",
         "phoneNumber": "Puhelinnumero",
+        "primaryAddress": "Vakituinen osoite",
         "search": "Hae",
         "zone": "Alue"
       },

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -40,11 +40,12 @@
     },
     "permitDetail": {
       "customerInfo": {
-        "address": "Adress",
         "email": "E-post",
+        "otherAddress": "Temporär adress",
         "parkingZone": "Parkeringszon",
         "personalID": "Personligt ID",
         "phoneNumber": "Telefonnummer",
+        "primaryAddress": "Permanent adress",
         "sendMessageToEmail": "Skicka meddelande till kundens e-post",
         "title": "Kundinformation"
       },
@@ -109,9 +110,10 @@
         "registrationNumber": "Registreringsnummer"
       },
       "permitsDataTable": {
-        "address": "Adress",
         "endTime": "Sluttid",
         "name": "Namn",
+        "otherAddress": "Temporär adress",
+        "primaryAddress": "Permanent adress",
         "registrationNumber": "Registreringsnummer",
         "startTime": "Starttid",
         "status": "Status",
@@ -159,15 +161,16 @@
         "validPeriodInMonths": "Giltig period i månader"
       },
       "personalInfo": {
-        "address": "Adress",
         "addressSecurityBan": "Säkerhetsförbud: Adress och namn kommer inte att registreras",
         "driverLicenseChecked": "Förarlicensen är kontrollerad",
         "email": "E-post",
         "firstName": "Förnamn",
         "lastName": "Efternamn",
+        "otherAddress": "Temporär adress",
         "personalId": "Personligt ID",
         "personalInfo": "Personlig information",
         "phoneNumber": "Telefonnummer",
+        "primaryAddress": "Permanent adress",
         "search": "Sök",
         "zone": "Zon"
       },

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -51,6 +51,26 @@ const CUSTOMER_QUERY = gql`
           }
         }
       }
+      otherAddress {
+        city
+        citySv
+        streetName
+        streetNumber
+        postalCode
+        zone {
+          name
+          label
+          labelSv
+          residentProducts {
+            unitPrice
+            startDate
+            endDate
+            vat
+            lowEmissionDiscount
+            secondaryVehicleIncreaseRate
+          }
+        }
+      }
     }
   }
 `;

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -50,6 +50,14 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        otherAddress {
+          streetName
+          streetNameSv
+          streetNumber
+          city
+          citySv
+          postalCode
+        }
       }
       vehicle {
         manufacturer

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -50,6 +50,14 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        otherAddress {
+          streetName
+          streetNameSv
+          streetNumber
+          city
+          citySv
+          postalCode
+        }
       }
       vehicle {
         manufacturer

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -54,6 +54,14 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        otherAddress {
+          streetName
+          streetNameSv
+          streetNumber
+          city
+          citySv
+          postalCode
+        }
       }
       vehicle {
         manufacturer

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -50,6 +50,14 @@ const PERMITS_QUERY = gql`
             citySv
             postalCode
           }
+          otherAddress {
+            streetName
+            streetNameSv
+            streetNumber
+            city
+            citySv
+            postalCode
+          }
         }
         vehicle {
           manufacturer

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface Customer {
   lastName: string;
   nationalIdNumber: string;
   primaryAddress?: Address | AddressInput;
+  otherAddress?: Address | AddressInput;
   email: string;
   phoneNumber: string;
   zone?: ParkingZone;
@@ -165,6 +166,7 @@ export interface CustomerInput {
   lastName: string;
   nationalIdNumber: string;
   primaryAddress?: AddressInput;
+  otherAddress?: AddressInput;
   zone?: string;
   email: string;
   phoneNumber: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,21 +109,25 @@ export function convertToCustomerInput(customer: Customer): CustomerInput {
     lastName,
     nationalIdNumber,
     primaryAddress,
+    otherAddress,
     email,
     phoneNumber,
     zone,
     addressSecurityBan,
     driverLicenseChecked,
   } = customer;
-  const addressInput =
+  const primaryAddressInput =
     primaryAddress && isAddressInput(primaryAddress)
       ? primaryAddress
       : undefined;
+  const otherAddressInput =
+    otherAddress && isAddressInput(otherAddress) ? otherAddress : undefined;
   return {
     firstName,
     lastName,
     nationalIdNumber,
-    primaryAddress: addressInput,
+    primaryAddress: primaryAddressInput,
+    otherAddress: otherAddressInput,
     email,
     phoneNumber,
     zone: zone?.name,


### PR DESCRIPTION
The UI for address selection is updated and there's no need to use an edit button. Admins could choose between two addresses, as well as enter address details. Also we include other address information in permit detail page and permit list view.

Note that we are using **primary address** and **other address** in the code to match the naming in both backend and frontend. But they are presented as **permanent** and **temporary** addresses.

Refs: PV-385

![image](https://user-images.githubusercontent.com/1997039/161040254-eb51ce87-0580-457e-ac14-3b3918929293.png)
