### PR TITLE
Auto-select the zone when fetch profile from backend or switch the address

### DIFF
--- a/src/components/common/AddressSearch.tsx
+++ b/src/components/common/AddressSearch.tsx
@@ -12,7 +12,6 @@ interface AddressSearchProps {
   disabled?: boolean;
   label?: string;
   address?: Address;
-  errorText?: string;
   onSelect: (address: AddressInput) => void;
 }
 
@@ -26,7 +25,6 @@ const AddressSearch = ({
   disabled = false,
   label,
   address,
-  errorText,
   onSelect,
 }: AddressSearchProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
@@ -72,7 +70,6 @@ const AddressSearch = ({
       id="address"
       label={label}
       value={address ? formatAddress(address, i18n.language) : ''}
-      errorText={errorText}
     />
   );
 };

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -117,11 +117,16 @@ const CreateResidentPermit = (): React.ReactElement => {
   const [getCustomer] = useLazyQuery<{
     customer: Customer;
   }>(CUSTOMER_QUERY, {
-    onCompleted: data => {
+    onCompleted: ({ customer: newCustomer }) => {
       setPersonSearchError('');
+      const defaultZone =
+        newCustomer?.primaryAddress?.zone || customer?.otherAddress?.zone;
       setPermit({
         ...permit,
-        customer: data.customer,
+        customer: {
+          ...newCustomer,
+          zone: defaultZone,
+        },
       });
     },
     onError: error => setPersonSearchError(error.message),

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Address {
   city: string;
   citySv: string;
   postalCode: string;
+  zone?: ParkingZone;
 }
 
 export interface Customer {


### PR DESCRIPTION
Previously the zone field is not automatically selected when fetching a new customer profile from DVV, or switching to use another address.

Refs: PV-327, PV-385