### PR TITLE
Add a readonly zone field to AddressForm

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -240,7 +240,8 @@
           "selectLocation": "Please select a location",
           "streetName": "Street name",
           "streetNameSv": "Street name (sv)",
-          "streetNumber": "Street number"
+          "streetNumber": "Street number",
+          "zone": "Zone"
         }
       },
       "lowEmissionCriteria": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -240,7 +240,8 @@
           "selectLocation": "Valitse sijainti",
           "streetName": "Kadun nimi",
           "streetNameSv": "Kasdun nimi (sv)",
-          "streetNumber": "Katunumero"
+          "streetNumber": "Katunumero",
+          "zone": "Alue"
         }
       },
       "lowEmissionCriteria": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -234,7 +234,8 @@
           "selectLocation": "Välj en plats",
           "streetName": "Gatunamn",
           "streetNameSv": "Gatunamn (sv)",
-          "streetNumber": "Gatunummer"
+          "streetNumber": "Gatunummer",
+          "zone": "Område"
         }
       },
       "lowEmissionCriteria": {

--- a/src/pages/superAdmin/addresses/CreateAddress.tsx
+++ b/src/pages/superAdmin/addresses/CreateAddress.tsx
@@ -8,7 +8,7 @@ import AddressForm from '../../../components/superAdmin/addresses/AddressForm';
 import { MutationResponse } from '../../../types';
 import styles from './CreateAddress.module.scss';
 
-const T_PATH = 'pages.superAdmin.addresses.createAddress';
+const T_PATH = 'pages.superAdmin.createAddress';
 
 const CREATE_ADDRESS_MUTATION = gql`
   mutation CreateAddress($address: AddressInput!) {

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -23,6 +23,8 @@ const ADDRESS_QUERY = gql`
       location
       zone {
         name
+        label
+        labelSv
       }
     }
   }

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -8,7 +8,7 @@ import AddressForm from '../../../components/superAdmin/addresses/AddressForm';
 import { Address, MutationResponse } from '../../../types';
 import styles from './EditAddress.module.scss';
 
-const T_PATH = 'pages.superAdmin.addresses.editAddress';
+const T_PATH = 'pages.superAdmin.editAddress';
 
 const ADDRESS_QUERY = gql`
   query GetAddress($addressId: ID!) {


### PR DESCRIPTION
The field reacts to location changes and queries the zone for the location when the user clicks a new location on the map.

Refs: PV-411