### PR TITLE
Apply no-cache fetch policy for queries

### DIFF
--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -124,6 +124,7 @@ const CreateResidentPermit = (): React.ReactElement => {
   const [getCustomer] = useLazyQuery<{
     customer: Customer;
   }>(CUSTOMER_QUERY, {
+    fetchPolicy: 'no-cache',
     onCompleted: ({ customer: newCustomer }) => {
       setPersonSearchError('');
       const defaultZone =

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -157,6 +157,7 @@ const EditResidentPermit = (): React.ReactElement => {
   // graphql queries and mutations
   useQuery<PermitDetailData>(PERMIT_DETAIL_QUERY, {
     variables: { permitId },
+    fetchPolicy: 'no-cache',
     onCompleted: ({ permitDetail }) => {
       // permit parking zone should override customer
       // zone as pre-selected vaule
@@ -176,7 +177,7 @@ const EditResidentPermit = (): React.ReactElement => {
   const [getPermitPriceChangeList] = useLazyQuery<{
     permitPriceChangeList: PermitPriceChange[];
   }>(PERMIT_PRICE_CHANGE_QUERY, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
     onCompleted: data => setPriceChangeList(data.permitPriceChangeList),
     onError: error => setErrorMessage(error.message),
   });

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -92,6 +92,7 @@ const EndPermit = (): React.ReactElement => {
   const [errorMessage, setErrorMessage] = useState('');
   const { loading, data } = useQuery<PermitDetailData>(PERMIT_DETAIL_QUERY, {
     variables,
+    fetchPolicy: 'no-cache',
     onError: error => setErrorMessage(error.message),
   });
   const [endPermit] = useMutation<MutationResponse>(END_PERMIT_MUTATION);

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -88,6 +88,7 @@ const PermitDetail = (): React.ReactElement => {
   const variables = { permitId: id };
   const { loading, data } = useQuery<PermitDetailData>(PERMIT_DETAIL_QUERY, {
     variables,
+    fetchPolicy: 'no-cache',
     onError: error => setErrorMessage(error.message),
   });
 

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -54,6 +54,7 @@ const EditAddress = (): React.ReactElement => {
   const variables = { addressId };
   const { loading, data } = useQuery<{ address: Address }>(ADDRESS_QUERY, {
     variables,
+    fetchPolicy: 'no-cache',
     onError: error => setErrorMessage(error.message),
   });
   const [updateAddress] = useMutation<MutationResponse>(

--- a/src/pages/superAdmin/products/EditProduct.tsx
+++ b/src/pages/superAdmin/products/EditProduct.tsx
@@ -54,6 +54,7 @@ const Products = (): React.ReactElement => {
   const variables = { productId };
   const { loading, data } = useQuery<{ product: Product }>(PRODUCT_QUERY, {
     variables,
+    fetchPolicy: 'no-cache',
     onError: error => setErrorMessage(error.message),
   });
   const [updateProduct] = useMutation<MutationResponse>(


### PR DESCRIPTION
The query caching causes problems that an updated object is not updated in the UI

no refs