### PR TITLE
Allow admins to request refunds for approval and accept refunds

### DIFF
--- a/src/components/refunds/RefundsDataTable.tsx
+++ b/src/components/refunds/RefundsDataTable.tsx
@@ -4,6 +4,7 @@ import { OrderBy, PageInfo, Refund } from '../../types';
 import { formatDateTimeDisplay } from '../../utils';
 import DataTable from '../common/DataTable';
 import { Column } from '../types';
+import RefundStatusLabel from './RefundStatusLabel';
 
 const T_PATH = 'components.refunds.refundsDataTable';
 
@@ -55,7 +56,7 @@ const RefundsDataTable = ({
     {
       name: t(`${T_PATH}.status`),
       field: 'status',
-      selector: ({ status }) => status,
+      selector: ({ status }) => <RefundStatusLabel status={status} />,
       orderFields: ['status'],
     },
     {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -398,6 +398,8 @@
       "title": "Edit Refund"
     },
     "refunds": {
+      "acceptRefunds": "Accept refunds",
+      "requestForApproval": "Request for approval",
       "title": "Returns"
     },
     "superAdmin": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -379,8 +379,8 @@
     },
     "permitDetail": {
       "changeHistory": "Käsittelyhistoria",
-      "edit": "Muokkaa",
       "downloadPdf": "Lataa tunnuksen tiedot PDF:nä",
+      "edit": "Muokkaa",
       "endPermit": "Päätä tunnus",
       "now": "Nyt",
       "permitId": "Tunnus ID",
@@ -399,6 +399,8 @@
       "title": "Muokkaa Palautusta"
     },
     "refunds": {
+      "acceptRefunds": "Hyväksy palautukset",
+      "requestForApproval": "Lähetä hyväksyttäväksi",
       "title": "Palautukset"
     },
     "superAdmin": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -373,8 +373,8 @@
     },
     "permitDetail": {
       "changeHistory": "Ändringshistorik",
-      "edit": "Redigera",
       "downloadPdf": "Ladda ner tillståndsinformation som PDF",
+      "edit": "Redigera",
       "endPermit": "Sluttillstånd",
       "now": "Nu",
       "permitId": "Tillstånds-ID",
@@ -393,6 +393,8 @@
       "title": "Redigera Retur"
     },
     "refunds": {
+      "acceptRefunds": "Acceptera återbetalningar",
+      "requestForApproval": "Begäran om godkännande",
       "title": "Returnerar"
     },
     "superAdmin": {

--- a/src/pages/Refunds.module.scss
+++ b/src/pages/Refunds.module.scss
@@ -2,4 +2,26 @@
 
 .container {
   margin: $spacing-m;
+
+  .footer {
+    padding: $spacing-m 0;
+    box-shadow: 0 -5px 5px -5px $color-black-30;
+    position: fixed;
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: white;
+
+    .actions {
+      display: flex;
+      flex-direction: row;
+      margin: 0 auto;
+      max-width: $breakpoint-xl;
+
+      .actionButton {
+        margin-left: $spacing-m;
+      }
+    }
+  }
 }

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -1,5 +1,10 @@
-import { gql, useQuery } from '@apollo/client';
-import { Notification } from 'hds-react';
+import { gql, useMutation, useQuery } from '@apollo/client';
+import {
+  Button,
+  IconArrowRight,
+  IconCheckCircle,
+  Notification,
+} from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -16,7 +21,7 @@ import {
   RefundsQueryData,
   RefundStatusOrAll,
 } from '../types';
-import styles from './Permits.module.scss';
+import styles from './Refunds.module.scss';
 
 const T_PATH = 'pages.refunds';
 
@@ -56,6 +61,18 @@ const REFUNDS_QUERY = gql`
   }
 `;
 
+const REQUEST_FOR_APPROVAL_MUTATION = gql`
+  mutation RequestForApproval($ids: [ID]!) {
+    requestForApproval(ids: $ids)
+  }
+`;
+
+const ACCEPT_REFUNDS_MUTATION = gql`
+  mutation AcceptRefunds($ids: [ID]!) {
+    acceptRefunds(ids: $ids)
+  }
+`;
+
 const Refunds = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -83,6 +100,22 @@ const Refunds = (): React.ReactElement => {
     fetchPolicy: 'no-cache',
     onError: error => setErrorMessage(error.message),
   });
+
+  const [requestForApproval] = useMutation<{ requestForApproval: number }>(
+    REQUEST_FOR_APPROVAL_MUTATION,
+    {
+      onCompleted: () => refetch(),
+      onError: error => setErrorMessage(error.message),
+    }
+  );
+
+  const [acceptRefunds] = useMutation<{ acceptRefunds: number }>(
+    ACCEPT_REFUNDS_MUTATION,
+    {
+      onCompleted: () => refetch(),
+      onError: error => setErrorMessage(error.message),
+    }
+  );
 
   if (loading) {
     return <div>loading...</div>;
@@ -126,6 +159,32 @@ const Refunds = (): React.ReactElement => {
           onExport={handleExport}
           onSelectionChange={selection => setSelectedRefunds(selection)}
         />
+      </div>
+      <div className={styles.footer}>
+        <div className={styles.actions}>
+          <Button
+            className={styles.actionButton}
+            theme="black"
+            iconLeft={<IconArrowRight />}
+            onClick={() =>
+              requestForApproval({
+                variables: { ids: selectedRefunds.map(refund => refund.id) },
+              })
+            }>
+            {t(`${T_PATH}.requestForApproval`)}
+          </Button>
+          <Button
+            className={styles.actionButton}
+            theme="black"
+            iconLeft={<IconCheckCircle />}
+            onClick={() =>
+              acceptRefunds({
+                variables: { ids: selectedRefunds.map(refund => refund.id) },
+              })
+            }>
+            {t(`${T_PATH}.acceptRefunds`)}
+          </Button>
+        </div>
       </div>
       {errorMessage && (
         <Notification

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -19,6 +19,7 @@ import {
   Refund,
   RefundSearchParams,
   RefundsQueryData,
+  RefundStatus,
   RefundStatusOrAll,
 } from '../types';
 import styles from './Refunds.module.scss';
@@ -104,7 +105,10 @@ const Refunds = (): React.ReactElement => {
   const [requestForApproval] = useMutation<{ requestForApproval: number }>(
     REQUEST_FOR_APPROVAL_MUTATION,
     {
-      onCompleted: () => refetch(),
+      onCompleted: () => {
+        refetch();
+        setSelectedRefunds([]);
+      },
       onError: error => setErrorMessage(error.message),
     }
   );
@@ -112,10 +116,22 @@ const Refunds = (): React.ReactElement => {
   const [acceptRefunds] = useMutation<{ acceptRefunds: number }>(
     ACCEPT_REFUNDS_MUTATION,
     {
-      onCompleted: () => refetch(),
+      onCompleted: () => {
+        refetch();
+        setSelectedRefunds([]);
+      },
       onError: error => setErrorMessage(error.message),
     }
   );
+
+  const canRequestForApproval =
+    selectedRefunds.length > 0 &&
+    selectedRefunds.every(refund => refund.status === RefundStatus.OPEN);
+  const canAcceptRefunds =
+    selectedRefunds.length > 0 &&
+    selectedRefunds.every(
+      refund => refund.status === RefundStatus.REQUEST_FOR_APPROVAL
+    );
 
   if (loading) {
     return <div>loading...</div>;
@@ -163,6 +179,7 @@ const Refunds = (): React.ReactElement => {
       <div className={styles.footer}>
         <div className={styles.actions}>
           <Button
+            disabled={!canRequestForApproval}
             className={styles.actionButton}
             theme="black"
             iconLeft={<IconArrowRight />}
@@ -174,6 +191,7 @@ const Refunds = (): React.ReactElement => {
             {t(`${T_PATH}.requestForApproval`)}
           </Button>
           <Button
+            disabled={!canAcceptRefunds}
             className={styles.actionButton}
             theme="black"
             iconLeft={<IconCheckCircle />}


### PR DESCRIPTION
Currently we do not have proper admin roles support, so both request for approval and accept refunds buttons are displayed to admins. The buttons are only enabled when selected refunds have the right statuses.

Refs: PV-423