### PR TITLE
PV-438: Fix refund detail page error

### DIFF
--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -31,6 +31,14 @@ const REFUND_DETAIL_QUERY = gql`
       createdBy
       modifiedAt
       modifiedBy
+      order {
+        id
+        orderPermits {
+          vehicle {
+            registrationNumber
+          }
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
## Description

Fix the error that causes the refund detail page to crash.

## Context

Navigating to a refund detail page (Returns > click a refund row) doesn't load because of an error. The error was caused by missing fields in the refund detail query.

## How has this been tested?

Manually, against a local development API and the test API.

## Manual testing instructions for reviewers

- Open the site, log in
- Navigate to "Returns"
- Click a row
- Nothing should explode and the refund details should show up (instead of a blank page)
- The console log should be free of any view-related errors

## Screenshots

![image](https://user-images.githubusercontent.com/2333857/189887862-6d5a9361-971c-4f01-a606-6324f49b60e4.png)
What the view should look like.