### PR TITLE
Fix Address component save button always being disabled

### DIFF
--- a/src/components/superAdmin/addresses/AddressForm.tsx
+++ b/src/components/superAdmin/addresses/AddressForm.tsx
@@ -62,14 +62,14 @@ const AddressForm = ({
         streetNameSv: '',
         streetNumber: '',
         postalCode: '',
-        city: '',
-        citySv: '',
+        city: 'Helsinki',
+        citySv: 'Helsingfors',
         location: HELSINKI_LOCATION,
       };
   const validationSchema = Yup.object().shape({
     streetName: Yup.string().required(t(`${T_PATH}.enterStreetName`)),
     streetNameSv: Yup.string(),
-    streetNumber: Yup.number().required(t(`${T_PATH}.enterStreetNumber`)),
+    streetNumber: Yup.string().required(t(`${T_PATH}.enterStreetNumber`)),
     postalCode: Yup.string()
       .required(t(`${T_PATH}.enterPostalCode`))
       .test('isPostalCode', t(`${T_PATH}.postalCode5Digits`), value =>
@@ -204,7 +204,7 @@ const AddressForm = ({
             <div className={styles.actions}>
               <Button
                 className={styles.submit}
-                disabled={!(props.dirty && props.isValid)}
+                disabled={!props.dirty || (props.dirty && !props.isValid)}
                 type="submit">
                 {t(`${T_PATH}.save`)}
               </Button>


### PR DESCRIPTION
## Description

`Save` button in address component is always being disabled.

## Context

Since address component  `save` button is always disabled it was preventing user to do any modification to the existing or add new address.

[PV-448](https://helsinkisolutionoffice.atlassian.net/browse/PV-448)

## How Has This Been Tested?

Login to admin ui. Check on tab `Ylläpito` select any address and try modifying it or try to create a new address.

## Manual Testing Instructions for Reviewers

Login to admin ui. Check on tab `Ylläpito` select any address and try modifying it or try to create a new address.

## Screenshots
<img width="955" alt="Screenshot 2022-10-10 at 10 10 25" src="https://user-images.githubusercontent.com/9328930/194815682-1882f22f-50f9-4ccd-9cb8-60203d938221.png">


