### PR TITLE
PV-453/PV-433/PV-458: In refunds/permits, add search buttons, make the query lazy and unify the styles

### DIFF
--- a/src/components/permits/PermitsDataTable.tsx
+++ b/src/components/permits/PermitsDataTable.tsx
@@ -13,7 +13,7 @@ import { Column } from '../types';
 const T_PATH = 'components.permits.permitsDataTable';
 
 export interface PermitsDataTableProps {
-  permits: Permit[];
+  permits?: Permit[];
   pageInfo?: PageInfo;
   loading: boolean;
   orderBy?: OrderBy;

--- a/src/components/permits/PermitsSearch.module.scss
+++ b/src/components/permits/PermitsSearch.module.scss
@@ -1,7 +1,6 @@
 @import '~hds-design-tokens/lib/all.scss';
 
 .container {
-  margin: $spacing-m;
   display: flex;
   flex-direction: column;
 

--- a/src/components/permits/PermitsSearch.module.scss
+++ b/src/components/permits/PermitsSearch.module.scss
@@ -21,3 +21,9 @@
     }
   }
 }
+
+.searchButton {
+  margin-top: auto;
+  margin-left: auto;
+  width: 180px;
+}

--- a/src/components/permits/PermitsSearch.tsx
+++ b/src/components/permits/PermitsSearch.tsx
@@ -1,4 +1,4 @@
-import { SearchInput } from 'hds-react';
+import { Button, IconSearch, SearchInput } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PermitSearchParams } from '../../types';
@@ -8,7 +8,7 @@ import StatusSelect from './StatusSelect';
 const T_PATH = 'components.permits.permitsSearch';
 export interface PermitsSearchProps {
   searchParams: PermitSearchParams;
-  onSearch: (searchInfo: PermitSearchParams) => void;
+  onSearch: (newSearchParams: PermitSearchParams) => void;
 }
 
 const PermitsSearch = ({
@@ -16,22 +16,34 @@ const PermitsSearch = ({
   onSearch,
 }: PermitsSearchProps): React.ReactElement => {
   const { t } = useTranslation();
-  const [localSearchParams, setLocalSearchParams] = useState(searchParams);
-  const { status, q } = localSearchParams;
+
+  const [status, setStatus] = useState(searchParams.status);
+  const [query, setQuery] = useState(searchParams.q);
+
+  const handleSubmit = () => onSearch({ status, q: query });
+
   return (
     <div className={styles.container}>
       <div className={styles.row}>
         <StatusSelect
           className={styles.statusSelect}
           value={status}
-          onChange={newStatus => setLocalSearchParams({ q, status: newStatus })}
+          onChange={setStatus}
         />
         <SearchInput
           className={styles.SearchInput}
           label=""
-          placeholder={q || t(`${T_PATH}.placeholder`)}
-          onSubmit={value => onSearch({ ...localSearchParams, q: value })}
+          placeholder={searchParams.q || t(`${T_PATH}.placeholder`)}
+          onSubmit={handleSubmit}
+          onChange={setQuery}
+          hideSearchButton
         />
+        <Button
+          className={styles.searchButton}
+          iconLeft={<IconSearch />}
+          onClick={handleSubmit}>
+          {t(`${T_PATH}.searchButton`)}
+        </Button>
       </div>
     </div>
   );

--- a/src/components/refunds/RefundsDataTable.tsx
+++ b/src/components/refunds/RefundsDataTable.tsx
@@ -10,7 +10,7 @@ const T_PATH = 'components.refunds.refundsDataTable';
 
 export interface RefundsDataTableProps {
   selection?: Refund[] | null;
-  refunds: Refund[];
+  refunds: Refund[] | undefined;
   pageInfo?: PageInfo;
   loading?: boolean;
   orderBy?: OrderBy;
@@ -18,7 +18,7 @@ export interface RefundsDataTableProps {
   onOrderBy?: (orderBy: OrderBy) => void;
   onRowClick?: (refund: Refund) => void;
   onExport?: () => void;
-  onSelectionChange: (refunds: Refund[]) => void;
+  onSelectionChange: (refunds: Refund[] | undefined) => void;
 }
 
 const RefundsDataTable = ({

--- a/src/components/refunds/RefundsSearch.module.scss
+++ b/src/components/refunds/RefundsSearch.module.scss
@@ -21,7 +21,7 @@
       width: 200px;
     }
 
-    .dateSeprator {
+    .dateSeparator {
       margin: 0 5px;
       width: 15px;
       height: 2px;
@@ -30,6 +30,12 @@
   }
 
   .searchInput {
-    width: 430px;
+    flex: 1 0 auto;
+  }
+
+  .searchButton {
+    margin-top: auto;
+    margin-left: auto;
+    width: 180px;
   }
 }

--- a/src/components/refunds/RefundsSearch.tsx
+++ b/src/components/refunds/RefundsSearch.tsx
@@ -1,9 +1,10 @@
-import { formatISO } from 'date-fns';
-import { Checkbox, DateInput, SearchInput, SelectionGroup } from 'hds-react';
+import { formatISO, parse } from 'date-fns';
+import { Button, DateInput, IconSearch, SearchInput } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentType, RefundSearchParams } from '../../types';
-import { formatDateDisplay } from '../../utils';
+import { joinSet } from '../../utils';
+import FilterOptions from '../orders/FilterOptions';
 import styles from './RefundsSearch.module.scss';
 import RefundStatusSelect from './RefundStatusSelect';
 
@@ -19,44 +20,50 @@ const RefundsSearch = ({
   onSearch,
 }: RefundsSearchProps): React.ReactElement => {
   const { t } = useTranslation();
-  // the search only trigged when user clicks the search button
-  // so we need to keep a local state of search params
-  const [localSearchParams, setLocalSearchParams] = useState(searchParams);
-  const { q, startDate, endDate, status, paymentTypes } = localSearchParams;
-  const paymentTypeArray = paymentTypes.split(',');
+
+  const [status, setStatus] = useState(searchParams.status);
+  const [query, setQuery] = useState(searchParams.q);
+  const [startDate, setStartDate] = useState(searchParams.startDate);
+  const [endDate, setEndDate] = useState(searchParams.endDate);
+  const [paymentTypes, setPaymentTypes] = useState(
+    new Set(searchParams.paymentTypes?.split(',').filter(val => val))
+  );
+
+  const formatDate = (date: string) => {
+    const parsedDate = parse(date, 'd.M.yyyy', new Date());
+    return formatISO(parsedDate, { representation: 'date' });
+  };
+
+  const handleSubmit = () =>
+    onSearch({
+      startDate: startDate ? formatDate(startDate) : '',
+      endDate: endDate ? formatDate(endDate) : '',
+      paymentTypes: joinSet(paymentTypes),
+      status,
+      q: query,
+    });
+
   return (
     <div className={styles.container}>
       <div className={styles.row}>
         <RefundStatusSelect
           className={styles.statusSelect}
           value={status}
-          onChange={value =>
-            setLocalSearchParams({ ...localSearchParams, status: value })
-          }
+          onChange={setStatus}
         />
         <div className={styles.dateRange}>
           <DateInput
             className={styles.startDate}
             id="startDate"
-            value={startDate && formatDateDisplay(startDate)}
-            onChange={(_, date) =>
-              setLocalSearchParams({
-                ...localSearchParams,
-                startDate: formatISO(date, { representation: 'date' }),
-              })
-            }
+            value={startDate}
+            onChange={setStartDate}
           />
-          <div className={styles.dateSeprator} />
+          <div className={styles.dateSeparator} />
           <DateInput
             className={styles.endDate}
-            id="sendDate"
-            value={endDate && formatDateDisplay(endDate)}
-            onChange={(_, date) =>
-              setLocalSearchParams({
-                ...localSearchParams,
-                endDate: formatISO(date, { representation: 'date' }),
-              })
-            }
+            id="endDate"
+            value={endDate}
+            onChange={setEndDate}
           />
         </div>
         <SearchInput
@@ -64,47 +71,34 @@ const RefundsSearch = ({
           label=""
           // HDS search input does not support passing a default value
           // so we have to use the placeholder property here
-          placeholder={q || t(`${T_PATH}.searchPlaceholder`)}
-          onSubmit={value => onSearch({ ...localSearchParams, q: value })}
+          placeholder={query || t(`${T_PATH}.searchPlaceholder`)}
+          onSubmit={() => handleSubmit()}
+          onChange={setQuery}
+          hideSearchButton
         />
       </div>
       <div className={styles.row}>
-        <SelectionGroup direction="horizontal">
-          <Checkbox
-            id="webshop"
-            name="paymentType"
-            label={t(`${T_PATH}.webshop`)}
-            checked={paymentTypeArray.includes(PaymentType.ONLINE_PAYMENT)}
-            onChange={e => {
-              const newPaymentTypes = e.target.checked
-                ? [...paymentTypeArray, PaymentType.ONLINE_PAYMENT]
-                : paymentTypeArray.filter(
-                    item => item !== PaymentType.ONLINE_PAYMENT
-                  );
-              setLocalSearchParams({
-                ...localSearchParams,
-                paymentTypes: newPaymentTypes.join(','),
-              });
-            }}
-          />
-          <Checkbox
-            id="cash"
-            name="paymentType"
-            label={t(`${T_PATH}.cash`)}
-            checked={paymentTypeArray.includes(PaymentType.CASHIER_PAYMENT)}
-            onChange={e => {
-              const newPaymentTypes = e.target.checked
-                ? [...paymentTypeArray, PaymentType.CASHIER_PAYMENT]
-                : paymentTypeArray.filter(
-                    item => item !== PaymentType.CASHIER_PAYMENT
-                  );
-              setLocalSearchParams({
-                ...localSearchParams,
-                paymentTypes: newPaymentTypes.join(','),
-              });
-            }}
-          />
-        </SelectionGroup>
+        <FilterOptions
+          label={t(`${T_PATH}.paymentType`)}
+          state={paymentTypes}
+          onChange={setPaymentTypes}
+          options={[
+            {
+              i18n: 'enums.paymentType.cashierPayment',
+              value: PaymentType.CASHIER_PAYMENT,
+            },
+            {
+              i18n: 'enums.paymentType.onlinePayment',
+              value: PaymentType.ONLINE_PAYMENT,
+            },
+          ]}
+        />
+        <Button
+          className={styles.searchButton}
+          iconLeft={<IconSearch />}
+          onClick={() => handleSubmit()}>
+          {t(`${T_PATH}.searchButton`)}
+        </Button>
       </div>
     </div>
   );

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -195,7 +195,9 @@
       "refundsSearch": {
         "cash": "Kassa",
         "searchPlaceholder": "Nimi, rekisterinro tai tilausnumero",
-        "webshop": "Verkkokauppa"
+        "webshop": "Verkkokauppa",
+        "searchButton": "Hae",
+        "paymentType": "Maksu"
       },
       "refundStatusSelect": {
         "status": "Tila"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -169,7 +169,8 @@
         "zone": "Alue"
       },
       "permitsSearch": {
-        "placeholder": "Hae"
+        "placeholder": "Hae",
+        "searchButton": "Hae"
       },
       "permitsSearchFilters": {
         "filterList": "Suodata listaa"

--- a/src/pages/Orders.module.scss
+++ b/src/pages/Orders.module.scss
@@ -3,15 +3,4 @@
 .container {
   display: flex;
   flex-direction: column;
-
-  .header {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-
-    .title {
-      font-size: $fontsize-heading-l;
-    }
-  }
 }

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -170,7 +170,7 @@ const Orders = (): React.ReactElement => {
 
   return (
     <div className={styles.container}>
-      <h2 className={styles.title}>{t(`${T_PATH}.title`)}</h2>
+      <h2>{t(`${T_PATH}.title`)}</h2>
       <OrdersSearch searchParams={ordersSearchParams} onSubmit={handleSearch} />
       <div className={styles.content}>
         <OrdersDataTable

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -7,9 +7,9 @@ import { useSearchParams } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import OrdersDataTable from '../components/orders/OrdersDataTable';
 import OrdersSearch from '../components/orders/OrdersSearch';
-import { OrderDirection } from '../components/types';
 import useExportData from '../export/useExportData';
 import { formatExportUrl } from '../export/utils';
+import { useOrderByParam, usePageParam } from '../hooks/searchParam';
 import {
   OrderBy,
   OrderSearchParams,
@@ -82,16 +82,8 @@ const Orders = (): React.ReactElement => {
   const exportData = useExportData();
   const [errorMessage, setErrorMessage] = useState('');
 
-  const pageParam = searchParams.get('page');
-  const orderFieldParam = searchParams.get('orderField');
-  const orderDirectionParam = searchParams.get('orderDirection');
-
-  const page = pageParam ? parseInt(pageParam, 10) : 1;
-  const orderBy: OrderBy = {
-    orderField: orderFieldParam || '',
-    orderDirection:
-      (orderDirectionParam as OrderDirection) || OrderDirection.DESC,
-  };
+  const { pageParam: page, setPageParam } = usePageParam();
+  const { orderByParam: orderBy, setOrderBy } = useOrderByParam();
 
   const reformatISODate = (dateString: string) =>
     format(parse(dateString, 'yyyy-MM-dd', new Date()), 'd.M.yyyy');
@@ -143,8 +135,7 @@ const Orders = (): React.ReactElement => {
   };
 
   const handlePage = (newPage: number) => {
-    searchParams.set('page', newPage.toString());
-    setSearchParams(searchParams, { replace: true });
+    setPageParam(newPage);
 
     refetch({
       pageInput: { page: newPage },
@@ -152,8 +143,7 @@ const Orders = (): React.ReactElement => {
   };
 
   const handleOrderBy = (newOrderBy: OrderBy) => {
-    Object.entries(newOrderBy).forEach(([k, v]) => searchParams.set(k, v));
-    setSearchParams(searchParams, { replace: true });
+    setOrderBy(newOrderBy);
 
     refetch({
       orderBy: newOrderBy,

--- a/src/pages/Permits.module.scss
+++ b/src/pages/Permits.module.scss
@@ -9,9 +9,5 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-
-    .title {
-      font-size: $fontsize-heading-l;
-    }
   }
 }

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -1,4 +1,4 @@
-import { gql, useQuery } from '@apollo/client';
+import { gql, useLazyQuery } from '@apollo/client';
 import { Button, IconArrowRight, Notification } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -101,24 +101,30 @@ const Permits = (): React.ReactElement => {
     orderBy,
     searchParams: permitSearchParams,
   };
-  const { loading, data, refetch } = useQuery<PermitsQueryData>(PERMITS_QUERY, {
-    variables,
-    fetchPolicy: 'no-cache',
-    onError: error => setErrorMessage(error.message),
-  });
-  const handleSearch = (newPermitSearchParams: PermitSearchParams) => {
-    const urlSearchParams = {
-      ...newPermitSearchParams,
-      ...orderBy,
-      page,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
+
+  const [getPermits, { loading, data, refetch }] =
+    useLazyQuery<PermitsQueryData>(PERMITS_QUERY, {
+      variables,
+      fetchPolicy: 'no-cache',
+      onError: error => setErrorMessage(error.message),
     });
-    refetch({
-      pageInput: { page },
-      orderBy,
-      searchParams: newPermitSearchParams,
+
+  const handleSearch = (newSearchParams: PermitSearchParams) => {
+    setSearchParams(
+      new URLSearchParams({
+        ...newSearchParams,
+        ...orderBy,
+        page: '1',
+      }),
+      { replace: true }
+    );
+
+    getPermits({
+      variables: {
+        searchParams: newSearchParams,
+        pageInput: { page: 1 },
+        orderBy,
+      },
     });
   };
 

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -167,7 +167,7 @@ const Permits = (): React.ReactElement => {
         onSearch={handleSearch}
       />
       <PermitsDataTable
-        permits={data?.permits.objects || []}
+        permits={data?.permits.objects}
         pageInfo={data?.permits.pageInfo}
         loading={loading}
         orderBy={orderBy}

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -7,9 +7,9 @@ import { useSearchParams } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import PermitsDataTable from '../components/permits/PermitsDataTable';
 import PermitsSearch from '../components/permits/PermitsSearch';
-import { OrderDirection } from '../components/types';
 import useExportData from '../export/useExportData';
 import { formatExportUrl } from '../export/utils';
+import { useOrderByParam, usePageParam } from '../hooks/searchParam';
 import {
   OrderBy,
   ParkingPermitStatusOrAll,
@@ -85,18 +85,12 @@ const Permits = (): React.ReactElement => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const exportData = useExportData();
-  const pageParam = searchParams.get('page');
-  const orderFieldParam = searchParams.get('orderField');
-  const orderDirectionParam = searchParams.get('orderDirection');
   const statusParam = searchParams.get('status');
   const qParam = searchParams.get('q');
 
-  const page = pageParam ? parseInt(pageParam, 10) : 1;
-  const orderBy = {
-    orderField: orderFieldParam || '',
-    orderDirection:
-      (orderDirectionParam as OrderDirection) || OrderDirection.DESC,
-  };
+  const { pageParam: page, setPageParam } = usePageParam();
+  const { orderByParam: orderBy, setOrderBy } = useOrderByParam();
+
   const permitSearchParams = {
     status: (statusParam as ParkingPermitStatusOrAll | null) || 'ALL',
     q: qParam || '',
@@ -127,36 +121,23 @@ const Permits = (): React.ReactElement => {
       searchParams: newPermitSearchParams,
     });
   };
+
   const handlePage = (newPage: number) => {
-    const urlSearchParams = {
-      ...permitSearchParams,
-      ...orderBy,
-      page: newPage,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
-    });
+    setPageParam(newPage);
+
     refetch({
-      pageInput: { newPage },
-      orderBy,
-      searchParams: permitSearchParams,
+      pageInput: { page: newPage },
     });
   };
+
   const handleOrderBy = (newOrderBy: OrderBy) => {
-    const urlSearchParams = {
-      ...permitSearchParams,
-      ...newOrderBy,
-      page,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
-    });
+    setOrderBy(newOrderBy);
+
     refetch({
-      pageInput: { page },
       orderBy: newOrderBy,
-      searchParams: permitSearchParams,
     });
   };
+
   const handleExport = () => {
     const url = formatExportUrl('permits', {
       ...permitSearchParams,

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -168,7 +168,7 @@ const Permits = (): React.ReactElement => {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
+        <h2>{t(`${T_PATH}.title`)}</h2>
         <Button
           iconLeft={<IconArrowRight />}
           onClick={() => navigate('create')}>

--- a/src/pages/Refunds.module.scss
+++ b/src/pages/Refunds.module.scss
@@ -1,7 +1,8 @@
 @import '~hds-design-tokens/lib/all.scss';
 
 .container {
-  margin: $spacing-m;
+  display: flex;
+  flex-direction: column;
 
   .footer {
     padding: $spacing-m 0;

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   IconArrowRight,
   IconCheckCircle,
-  LoadingSpinner,
   Notification,
 } from 'hds-react';
 import React, { useState } from 'react';
@@ -144,21 +143,15 @@ const Refunds = (): React.ReactElement => {
   );
 
   const canRequestForApproval =
+    selectedRefunds &&
     selectedRefunds.length > 0 &&
     selectedRefunds.every(refund => refund.status === RefundStatus.OPEN);
   const canAcceptRefunds =
+    selectedRefunds &&
     selectedRefunds.length > 0 &&
     selectedRefunds.every(
       refund => refund.status === RefundStatus.REQUEST_FOR_APPROVAL
     );
-
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-
-  if (!data) {
-    return <div>No data</div>;
-  }
 
   const handlePage = (newPage: number) => {
     setPageParam(newPage);
@@ -211,15 +204,15 @@ const Refunds = (): React.ReactElement => {
         />
         <RefundsDataTable
           selection={selectedRefunds}
-          refunds={data.refunds.objects}
-          pageInfo={data.refunds.pageInfo}
+          refunds={data?.refunds.objects}
+          pageInfo={data?.refunds.pageInfo}
           loading={loading}
           orderBy={orderBy}
           onPage={handlePage}
           onOrderBy={handleOrderBy}
           onRowClick={refund => navigate(refund.id)}
           onExport={handleExport}
-          onSelectionChange={selection => setSelectedRefunds(selection)}
+          onSelectionChange={selection => setSelectedRefunds(selection || [])}
         />
       </div>
       <div className={styles.footer}>

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -1,4 +1,4 @@
-import { gql, useMutation, useQuery } from '@apollo/client';
+import { gql, useLazyQuery, useMutation } from '@apollo/client';
 import {
   Button,
   IconArrowRight,
@@ -114,11 +114,13 @@ const Refunds = (): React.ReactElement => {
     orderBy,
     searchParams: refundSearchParams,
   };
-  const { loading, data, refetch } = useQuery<RefundsQueryData>(REFUNDS_QUERY, {
-    variables,
-    fetchPolicy: 'no-cache',
-    onError: error => setErrorMessage(error.message),
-  });
+
+  const [getRefunds, { loading, data, refetch }] =
+    useLazyQuery<RefundsQueryData>(REFUNDS_QUERY, {
+      variables,
+      fetchPolicy: 'no-cache',
+      onError: error => setErrorMessage(error.message),
+    });
 
   const [requestForApproval] = useMutation<{ requestForApproval: number }>(
     REQUEST_FOR_APPROVAL_MUTATION,
@@ -161,19 +163,22 @@ const Refunds = (): React.ReactElement => {
     });
   };
 
-  const handleSearch = (newRefundSearchParams: RefundSearchParams) => {
-    const urlSearchParams = {
-      ...newRefundSearchParams,
-      ...orderBy,
-      page,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
-    });
-    refetch({
-      pageInput: { page },
-      orderBy,
-      searchParams: newRefundSearchParams,
+  const handleSearch = (newSearchParams: RefundSearchParams) => {
+    setSearchParams(
+      new URLSearchParams({
+        ...newSearchParams,
+        ...orderBy,
+        page: '1',
+      }),
+      { replace: true }
+    );
+
+    getRefunds({
+      variables: {
+        searchParams: newSearchParams,
+        pageInput: { page: 1 },
+        orderBy,
+      },
     });
   };
 

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -13,9 +13,9 @@ import { useSearchParams } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import RefundsDataTable from '../components/refunds/RefundsDataTable';
 import RefundsSearch from '../components/refunds/RefundsSearch';
-import { OrderDirection } from '../components/types';
 import useExportData from '../export/useExportData';
 import { formatExportUrl } from '../export/utils';
+import { useOrderByParam, usePageParam } from '../hooks/searchParam';
 import {
   OrderBy,
   Refund,
@@ -94,21 +94,15 @@ const Refunds = (): React.ReactElement => {
   const [errorMessage, setErrorMessage] = useState('');
   const [selectedRefunds, setSelectedRefunds] = useState<Refund[]>([]);
 
-  const pageParam = searchParams.get('page');
-  const orderFieldParam = searchParams.get('orderField');
-  const orderDirectionParam = searchParams.get('orderDirection');
+  const { pageParam: page, setPageParam } = usePageParam();
+  const { orderByParam: orderBy, setOrderBy } = useOrderByParam();
+
   const statusParam = searchParams.get('status');
   const qParam = searchParams.get('q');
   const startDateParam = searchParams.get('startDate');
   const endDateParam = searchParams.get('endDate');
   const paymentTypesParam = searchParams.get('paymentTypes');
 
-  const page = pageParam ? parseInt(pageParam, 10) : 1;
-  const orderBy: OrderBy = {
-    orderField: orderFieldParam || '',
-    orderDirection:
-      (orderDirectionParam as OrderDirection) || OrderDirection.DESC,
-  };
   const refundSearchParams: RefundSearchParams = {
     q: qParam || '',
     startDate: startDateParam || '',
@@ -167,18 +161,10 @@ const Refunds = (): React.ReactElement => {
   }
 
   const handlePage = (newPage: number) => {
-    const urlSearchParams = {
-      ...refundSearchParams,
-      ...orderBy,
-      page: newPage,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
-    });
+    setPageParam(newPage);
+
     refetch({
-      pageInput: { newPage },
-      orderBy,
-      searchParams: refundSearchParams,
+      pageInput: { page: newPage },
     });
   };
 
@@ -199,18 +185,10 @@ const Refunds = (): React.ReactElement => {
   };
 
   const handleOrderBy = (newOrderBy: OrderBy) => {
-    const urlSearchParams = {
-      ...refundSearchParams,
-      ...newOrderBy,
-      page,
-    };
-    setSearchParams(urlSearchParams as unknown as Record<string, string>, {
-      replace: true,
-    });
+    setOrderBy(newOrderBy);
+
     refetch({
-      pageInput: { page },
       orderBy: newOrderBy,
-      searchParams: refundSearchParams,
     });
   };
 

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -225,7 +225,7 @@ const Refunds = (): React.ReactElement => {
 
   return (
     <div className={styles.container}>
-      <h2 className={styles.title}>{t(`${T_PATH}.title`)}</h2>
+      <h2>{t(`${T_PATH}.title`)}</h2>
       <div className={styles.content}>
         <RefundsSearch
           searchParams={refundSearchParams}


### PR DESCRIPTION
## Description

Adds a search button, makes the query lazy (i.e. doesn't fire immediately but only after clicking the search button), and makes the pages look similar to the orders view. Applies to both the refunds and the permits view.

## Context

In a nutshell; the search functionality changes are required for GDPR reasons, related to logging.

The styling issue, not so much, but it probably looks nicer if each search view doesn't look different to each other. And it makes the code more similar to each other as well.

[PV-433](https://helsinkisolutionoffice.atlassian.net/browse/PV-433)
[PV-453](https://helsinkisolutionoffice.atlassian.net/browse/PV-453)
[PV-458](https://helsinkisolutionoffice.atlassian.net/browse/PV-458)

## How Has This Been Tested?

Manually. No unit tests.
<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

In both views,:
- Check that when opening the page, there's nothing loaded (the tables should only show "Syötä hakuehto")
- Check that the search button does what it's supposed to do, i.e. fire the search

## Screenshots

![image](https://user-images.githubusercontent.com/2333857/197193698-168b0ea0-1bfc-48bb-bddb-3272492ec073.png)
The new permits view, with an empty table. The empty table looks the same in the refunds view as well.

![image](https://user-images.githubusercontent.com/2333857/197193868-ddb80953-644c-42e2-b0e5-1d0d7b9cdd3f.png)
The new refunds view, with data in it.

![image](https://user-images.githubusercontent.com/2333857/197193924-b461cb49-2f4a-4a36-aa7a-4e4ac9918f36.png)
For comparison, the orders view.
