### PR TITLE
Role base access control admin UI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     "no-unused-vars": 0,
     "no-magic-numbers": [
       "error",
-      { "ignoreArrayIndexes": true, "ignore": [1000, -1, 0, 1, 2, 3, 4, 5] }
+      { "ignoreArrayIndexes": true, "ignore": [1000, -1, 0, 1, 2, 3, 4, 5, 100, 90, 80, 70, 60, 50] }
     ],
     "arrow-body-style": ["error", "as-needed"],
     "line-comment-position": ["error", { "position": "above" }],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "husky": "^7.0.2",
     "i18next": "^21.9.1",
     "ibantools": "^4.1.4",
+    "jsonwebtoken": "^8.5.1",
     "leaflet": "^1.8.0",
     "node-sass": "^6.0.1",
     "oidc-client": "^1.11.5",

--- a/src/api/useUserRole.tsx
+++ b/src/api/useUserRole.tsx
@@ -1,0 +1,55 @@
+import { decode } from 'jsonwebtoken';
+import useApiToken from './useApiToken';
+
+export enum Groups {
+  SUPER_ADMIN = 'sg_kymp_pyva_asukpt_yllapito',
+  SANCTIONS_AND_RETURNS = 'sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset',
+  SANCTIONS = 'sg_kymp_pyva_asukpt_maksuseuraamukset',
+  CUSTOMER_SERVICE = 'sg_kymp_pyva_asukpt_asiakaspalvelu',
+  PREPARATORS = 'sg_kymp_pyva_asukpt_valmistelijat',
+  INSPECTORS = 'sg_kymp_pyva_asukpt_tarkastajat',
+}
+
+export enum UserRole {
+  SUPER_ADMIN = 100,
+  SANCTIONS_AND_RETURNS = 90,
+  SANCTIONS = 80,
+  CUSTOMER_SERVICE = 70,
+  PREPARATORS = 60,
+  INSPECTORS = 50,
+  UNKNOWN = 0,
+}
+
+const useUserRole = (): UserRole => {
+  const apiToken = useApiToken();
+  const decodedToken = decode(apiToken);
+  if (decodedToken) {
+    const adGroups = decodedToken.ad_groups;
+    if (adGroups.includes(Groups.SUPER_ADMIN)) {
+      return UserRole.SUPER_ADMIN;
+    }
+
+    if (adGroups.includes(Groups.SANCTIONS_AND_RETURNS)) {
+      return UserRole.SANCTIONS_AND_RETURNS;
+    }
+
+    if (adGroups.includes(Groups.SANCTIONS)) {
+      return UserRole.SANCTIONS;
+    }
+
+    if (adGroups.includes(Groups.CUSTOMER_SERVICE)) {
+      return UserRole.CUSTOMER_SERVICE;
+    }
+
+    if (adGroups.includes(Groups.PREPARATORS)) {
+      return UserRole.PREPARATORS;
+    }
+
+    if (adGroups.includes(Groups.INSPECTORS)) {
+      return UserRole.INSPECTORS;
+    }
+  }
+  return UserRole.UNKNOWN;
+};
+
+export default useUserRole;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { Navigation } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation, useNavigate } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { useClient } from '../auth/hooks';
 
 const T_PATH = 'components.header';
@@ -18,6 +19,7 @@ const isActiveLink = (path: string, currentPath: string): boolean =>
 const Header = (): React.ReactElement => {
   const navigate = useNavigate();
   const client = useClient();
+  const userRole = useUserRole();
   const user = client.getUser();
   const userName = user ? `${user.given_name} ${user.family_name}` : '';
   const { t, i18n } = useTranslation();
@@ -36,18 +38,22 @@ const Header = (): React.ReactElement => {
       path: '/refunds',
       label: t(`${T_PATH}.returns`),
     },
-    {
-      path: '/messages',
-      label: t(`${T_PATH}.messages`),
-    },
-    {
-      path: '/reports',
-      label: t(`${T_PATH}.reports`),
-    },
-    {
-      path: '/admin',
-      label: t(`${T_PATH}.admin`),
-    },
+    ...(userRole === UserRole.SUPER_ADMIN
+      ? [
+          {
+            path: '/messages',
+            label: t(`${T_PATH}.messages`),
+          },
+          {
+            path: '/reports',
+            label: t(`${T_PATH}.reports`),
+          },
+          {
+            path: '/admin',
+            label: t(`${T_PATH}.admin`),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -20,6 +20,8 @@ export interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
   onExport?: () => void;
   onSelectionChange?: (rows: T[] | undefined) => void;
+  showAllSelection?: boolean;
+  showCheckbox?: boolean;
 }
 
 const T_PATH = 'components.common.dataTable';
@@ -37,6 +39,8 @@ const DataTable = <T,>({
   onRowClick,
   onExport,
   onSelectionChange,
+  showAllSelection = true,
+  showCheckbox = true,
 }: DataTableProps<T>): React.ReactElement => {
   const { t } = useTranslation();
   return (
@@ -59,7 +63,7 @@ const DataTable = <T,>({
           </div>
         )}
       </div>
-      {selection && data && (
+      {showAllSelection && selection && data && (
         <div className={styles.selectionActions}>
           <Checkbox
             id="checkbox-select-all"
@@ -85,6 +89,7 @@ const DataTable = <T,>({
         onOrderBy={onOrderBy}
         onRowClick={onRowClick}
         onSelectionChange={onSelectionChange}
+        showCheckbox={showCheckbox}
       />
       {pageInfo && onPage && <Paginator pageInfo={pageInfo} onPage={onPage} />}
     </div>

--- a/src/components/common/table/Table.tsx
+++ b/src/components/common/table/Table.tsx
@@ -13,6 +13,7 @@ export interface TableProps<T> {
   columns: Column<T>[];
   data: T[] | undefined;
   loading: boolean;
+  showCheckbox?: boolean;
   orderBy?: OrderBy;
   rowIdSelector: (row: T) => string | number;
   onOrderBy?: (orderBy: OrderBy) => void;
@@ -32,6 +33,7 @@ const Table = <T,>({
   onOrderBy,
   onRowClick,
   onSelectionChange,
+  showCheckbox = true,
 }: TableProps<T>): React.ReactElement => {
   const { t } = useTranslation();
 
@@ -60,6 +62,7 @@ const Table = <T,>({
                 )
               : null
           }
+          showCheckbox={showCheckbox}
           onClick={onRowClick}
           key={rowId}
           rowId={rowId.toString()}

--- a/src/components/common/table/TableRow.tsx
+++ b/src/components/common/table/TableRow.tsx
@@ -10,6 +10,7 @@ export interface TableRowProps<T> {
   columns: Column<T>[];
   row: T;
   onClick?: (row: T) => void;
+  showCheckbox?: boolean;
   onSelectionChange?: (checked: boolean) => void;
 }
 
@@ -20,6 +21,7 @@ const TableRow = <T,>({
   row,
   onClick,
   onSelectionChange,
+  showCheckbox = true,
 }: TableRowProps<T>): React.ReactElement => (
   <tr
     className={classNames(styles.tableRow, { [styles.clickable]: onClick })}
@@ -33,18 +35,21 @@ const TableRow = <T,>({
         return (
           <td key={field}>
             <div className={styles.tableCell}>
-              <Checkbox
-                className={styles.checkbox}
-                id={`checkbox-${rowId}`}
-                label={selector(row)}
-                checked={selected}
-                onClick={e => {
-                  e.stopPropagation();
-                  if (onSelectionChange) {
-                    onSelectionChange(!selected);
-                  }
-                }}
-              />
+              {showCheckbox && (
+                <Checkbox
+                  className={styles.checkbox}
+                  id={`checkbox-${rowId}`}
+                  label={selector(row)}
+                  checked={selected}
+                  onClick={e => {
+                    e.stopPropagation();
+                    if (onSelectionChange) {
+                      onSelectionChange(!selected);
+                    }
+                  }}
+                />
+              )}
+              {!showCheckbox && selector(row)}
             </div>
           </td>
         );

--- a/src/components/refunds/RefundsDataTable.tsx
+++ b/src/components/refunds/RefundsDataTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import useUserRole, { UserRole } from '../../api/useUserRole';
 import { OrderBy, PageInfo, Refund } from '../../types';
 import { formatDateTimeDisplay } from '../../utils';
 import DataTable from '../common/DataTable';
@@ -34,6 +35,7 @@ const RefundsDataTable = ({
   onSelectionChange,
 }: RefundsDataTableProps): React.ReactElement => {
   const { t } = useTranslation();
+  const userRole = useUserRole();
   const columns: Column<Refund>[] = [
     {
       name: t(`${T_PATH}.refundNumber`),
@@ -109,6 +111,8 @@ const RefundsDataTable = ({
       onRowClick={onRowClick}
       onExport={onExport}
       onSelectionChange={onSelectionChange}
+      showAllSelection={userRole >= UserRole.SANCTIONS}
+      showCheckbox={userRole >= UserRole.SANCTIONS}
     />
   );
 };

--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 // eslint-disable-next-line import/no-namespace
 import * as Yup from 'yup';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
 import RefundsDataTable from '../components/refunds/RefundsDataTable';
@@ -54,6 +55,7 @@ const UPDATE_REFUND_MUTATION = gql`
 const RefundDetail = (): React.ReactElement => {
   const navigate = useNavigate();
   const exportData = useExportData();
+  const userRole = useUserRole();
   const { t } = useTranslation();
   const { id: refundId } = useParams();
   const [errorMessage, setErrorMessage] = useState('');
@@ -135,6 +137,7 @@ const RefundDetail = (): React.ReactElement => {
                   value={values.name}
                   onChange={handleChange}
                   onBlur={handleBlur}
+                  disabled={userRole <= UserRole.PREPARATORS}
                   errorText={
                     touched.name && errors.name ? errors.name : undefined
                   }
@@ -142,6 +145,7 @@ const RefundDetail = (): React.ReactElement => {
                 <TextInput
                   required
                   className={styles.ibanInput}
+                  disabled={userRole <= UserRole.PREPARATORS}
                   id="iban"
                   name="iban"
                   label="IBAN"
@@ -157,12 +161,14 @@ const RefundDetail = (): React.ReactElement => {
                 <RefundsDataTable refunds={[data.refund]} />
               </div>
               <div className={styles.actions}>
-                <Button
-                  className={styles.save}
-                  disabled={!(dirty && isValid)}
-                  type="submit">
-                  {t(`${T_PATH}.save`)}
-                </Button>
+                {userRole > UserRole.PREPARATORS && (
+                  <Button
+                    className={styles.save}
+                    disabled={!(dirty && isValid)}
+                    type="submit">
+                    {t(`${T_PATH}.save`)}
+                  </Button>
+                )}
                 <Button
                   className={styles.downloadPdf}
                   variant="secondary"
@@ -170,12 +176,14 @@ const RefundDetail = (): React.ReactElement => {
                   onClick={handleExport}>
                   {t(`${T_PATH}.downloadPdf`)}
                 </Button>
-                <Button
-                  variant="secondary"
-                  className={styles.cancel}
-                  onClick={() => navigate('/refunds')}>
-                  {t(`${T_PATH}.cancel`)}
-                </Button>
+                {userRole > UserRole.PREPARATORS && (
+                  <Button
+                    variant="secondary"
+                    className={styles.cancel}
+                    onClick={() => navigate('/refunds')}>
+                    {t(`${T_PATH}.cancel`)}
+                  </Button>
+                )}
               </div>
             </form>
           )}

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -246,36 +246,40 @@ const Refunds = (): React.ReactElement => {
           onSelectionChange={selection => setSelectedRefunds(selection)}
         />
       </div>
-      <div className={styles.footer}>
-        <div className={styles.actions}>
-          <Button
-            disabled={!canRequestForApproval}
-            className={styles.actionButton}
-            theme="black"
-            iconLeft={<IconArrowRight />}
-            onClick={() =>
-              requestForApproval({
-                variables: { ids: selectedRefunds.map(refund => refund.id) },
-              })
-            }>
-            {t(`${T_PATH}.requestForApproval`)}
-          </Button>
-          {userRole >= UserRole.SANCTIONS_AND_RETURNS && (
+      {userRole >= UserRole.SANCTIONS && (
+        <div className={styles.footer}>
+          <div className={styles.actions}>
             <Button
-              disabled={!canAcceptRefunds}
+              disabled={!canRequestForApproval}
               className={styles.actionButton}
               theme="black"
-              iconLeft={<IconCheckCircle />}
+              iconLeft={<IconArrowRight />}
               onClick={() =>
-                acceptRefunds({
+                requestForApproval({
                   variables: { ids: selectedRefunds.map(refund => refund.id) },
                 })
               }>
-              {t(`${T_PATH}.acceptRefunds`)}
+              {t(`${T_PATH}.requestForApproval`)}
             </Button>
-          )}
+            {userRole >= UserRole.SANCTIONS_AND_RETURNS && (
+              <Button
+                disabled={!canAcceptRefunds}
+                className={styles.actionButton}
+                theme="black"
+                iconLeft={<IconCheckCircle />}
+                onClick={() =>
+                  acceptRefunds({
+                    variables: {
+                      ids: selectedRefunds.map(refund => refund.id),
+                    },
+                  })
+                }>
+                {t(`${T_PATH}.acceptRefunds`)}
+              </Button>
+            )}
+          </div>
         </div>
-      </div>
+      )}
       {errorMessage && (
         <Notification
           type="error"

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -10,6 +10,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import RefundsDataTable from '../components/refunds/RefundsDataTable';
 import RefundsSearch from '../components/refunds/RefundsSearch';
@@ -89,6 +90,7 @@ const ACCEPT_REFUNDS_MUTATION = gql`
 const Refunds = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const userRole = useUserRole();
   const [searchParams, setSearchParams] = useSearchParams();
   const exportData = useExportData();
   const [errorMessage, setErrorMessage] = useState('');
@@ -258,18 +260,20 @@ const Refunds = (): React.ReactElement => {
             }>
             {t(`${T_PATH}.requestForApproval`)}
           </Button>
-          <Button
-            disabled={!canAcceptRefunds}
-            className={styles.actionButton}
-            theme="black"
-            iconLeft={<IconCheckCircle />}
-            onClick={() =>
-              acceptRefunds({
-                variables: { ids: selectedRefunds.map(refund => refund.id) },
-              })
-            }>
-            {t(`${T_PATH}.acceptRefunds`)}
-          </Button>
+          {userRole >= UserRole.SANCTIONS_AND_RETURNS && (
+            <Button
+              disabled={!canAcceptRefunds}
+              className={styles.actionButton}
+              theme="black"
+              iconLeft={<IconCheckCircle />}
+              onClick={() =>
+                acceptRefunds({
+                  variables: { ids: selectedRefunds.map(refund => refund.id) },
+                })
+              }>
+              {t(`${T_PATH}.acceptRefunds`)}
+            </Button>
+          )}
         </div>
       </div>
       {errorMessage && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3432,6 +3432,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -4816,6 +4821,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6271,7 +6283,6 @@ hds-core@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.3.0.tgz#aec746d4714fca987cc9546cf2e225429e3e70e6"
   integrity sha512-8rIXvVbbuIK4qsQ5ZkOxnpfwj8FX9BpROxSGIDAs4qNJjtg86iVpXrpLdxmWoDPcHowRY/ZErA4PX+AmLDeESA==
-
 
 hds-design-tokens@^2.3.0:
   version "2.3.0"
@@ -7792,6 +7803,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
@@ -7809,6 +7836,23 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 killable@^1.0.1:
   version "1.0.1"
@@ -7976,6 +8020,16 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
 lodash.isequal@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -7986,10 +8040,30 @@ lodash.isfunction@3.0.9:
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
   integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
 
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
 lodash.isobject@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
   integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
 lodash.isundefined@3.0.1:
   version "3.0.1"
@@ -8005,6 +8079,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.pick@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
## Description

Role base access control admin UI

## Context

UI differences between admin roles:

### super_admin

- All tabs and all functions visible

### sanctions_and_returns

- Only show permits, orders and refunds tabs

- Refund-tab with both “Request for approval“- and “Accept refunds“-buttons

### sanctions

- Only show permits, orders and refunds tabs

- Refund-tab with only “Request for approval“ button

- (Optional: hide checkboxes from “Awaiting approval” status rows in returns, because they aren’t functional for this role)

### customer_service

- Only show permits, orders and refunds tabs

- In returns tab:

  - Hide sticky bottom with buttons
  
  - Hide checkboxes and “select all” function

### preparators

- Only show permits, orders and refunds tabs

- In permits tab, hide all buttons except “download as pdf”

- In returns tab, once a single return is opened:

- Change the input fields of name and IBAN to disabled – read only

- Hide buttons “save” and “cancel”

### inspectors

- Only show permits tab

- Don’t show personal information in the table

- Ensure the downloadable .csv doesn’t include personal information

- Once a permit is opened:

  - In the “Customer information” column in the middle, only show “Parking zone” information
  
  - Hide “Change history” in the bottom
  
  - Hide all the buttons in the bottom, also the .pdf download button


[PV-280](https://helsinkisolutionoffice.atlassian.net/browse/PV-280)

