### PR TITLE
Role base access control for inspectors

### DIFF
--- a/src/api/useUserRole.tsx
+++ b/src/api/useUserRole.tsx
@@ -3,7 +3,7 @@ import useApiToken from './useApiToken';
 
 export enum Groups {
   SUPER_ADMIN = 'sg_kymp_pyva_asukpt_yllapito',
-  SANCTIONS_AND_RETURNS = 'sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset',
+  SANCTIONS_AND_REFUNDS = 'sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset',
   SANCTIONS = 'sg_kymp_pyva_asukpt_maksuseuraamukset',
   CUSTOMER_SERVICE = 'sg_kymp_pyva_asukpt_asiakaspalvelu',
   PREPARATORS = 'sg_kymp_pyva_asukpt_valmistelijat',
@@ -12,7 +12,7 @@ export enum Groups {
 
 export enum UserRole {
   SUPER_ADMIN = 100,
-  SANCTIONS_AND_RETURNS = 90,
+  SANCTIONS_AND_REFUNDS = 90,
   SANCTIONS = 80,
   CUSTOMER_SERVICE = 70,
   PREPARATORS = 60,
@@ -29,8 +29,8 @@ const useUserRole = (): UserRole => {
       return UserRole.SUPER_ADMIN;
     }
 
-    if (adGroups.includes(Groups.SANCTIONS_AND_RETURNS)) {
-      return UserRole.SANCTIONS_AND_RETURNS;
+    if (adGroups.includes(Groups.SANCTIONS_AND_REFUNDS)) {
+      return UserRole.SANCTIONS_AND_REFUNDS;
     }
 
     if (adGroups.includes(Groups.SANCTIONS)) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,14 +30,18 @@ const Header = (): React.ReactElement => {
       path: '/permits',
       label: t(`${T_PATH}.permits`),
     },
-    {
-      path: '/orders',
-      label: t(`${T_PATH}.orders`),
-    },
-    {
-      path: '/refunds',
-      label: t(`${T_PATH}.refunds`),
-    },
+    ...(userRole > UserRole.INSPECTORS
+      ? [
+          {
+            path: '/orders',
+            label: t(`${T_PATH}.orders`),
+          },
+          {
+            path: '/refunds',
+            label: t(`${T_PATH}.refunds`),
+          },
+        ]
+      : []),
     ...(userRole === UserRole.SUPER_ADMIN
       ? [
           {

--- a/src/components/SuperAdminLayout.tsx
+++ b/src/components/SuperAdminLayout.tsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { Outlet } from 'react-router';
+import { Navigate } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import Divider from './common/Divider';
 import Header from './Header';
 import SideNav from './superAdmin/SideNav';
 import styles from './SuperAdminLayout.module.scss';
 
-const SuperAdminLayout = (): React.ReactElement => (
-  <div className={styles.mainLayout}>
-    <Header />
-    <Divider />
-    <div className={styles.contentContainer}>
-      <div className={styles.superAdminSideNav}>
-        <SideNav />
-      </div>
-      <div className={styles.superAdminContent}>
-        <Outlet />
+const SuperAdminLayout = (): React.ReactElement => {
+  const userRole = useUserRole();
+  if (userRole < UserRole.SUPER_ADMIN) {
+    return <Navigate to="/permits" />;
+  }
+  return (
+    <div className={styles.mainLayout}>
+      <Header />
+      <Divider />
+      <div className={styles.contentContainer}>
+        <div className={styles.superAdminSideNav}>
+          <SideNav />
+        </div>
+        <div className={styles.superAdminContent}>
+          <Outlet />
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default SuperAdminLayout;

--- a/src/components/permitDetail/CustomerInfo.tsx
+++ b/src/components/permitDetail/CustomerInfo.tsx
@@ -1,6 +1,7 @@
 import { Button, IconEnvelope } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import useUserRole, { UserRole } from '../../api/useUserRole';
 import { PermitDetail } from '../../types';
 import { formatAddress } from '../../utils';
 import styles from './CustomerInfo.module.scss';
@@ -17,9 +18,10 @@ const CustomerInfo = ({
   className,
   permit,
 }: CustomerInfoProps): React.ReactElement => {
+  const userRole = useUserRole();
   const { t, i18n } = useTranslation();
   const { customer, parkingZone } = permit;
-  const fields = [
+  let fields = [
     {
       label: t(`${T_PATH}.personalID`),
       value: customer.nationalIdNumber || '-',
@@ -49,6 +51,14 @@ const CustomerInfo = ({
       value: customer.email || '-',
     },
   ];
+  if (userRole <= UserRole.INSPECTORS) {
+    fields = [
+      {
+        label: t(`${T_PATH}.parkingZone`),
+        value: i18n.language === 'sv' ? parkingZone.labelSv : parkingZone.label,
+      },
+    ];
+  }
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
@@ -61,7 +71,7 @@ const CustomerInfo = ({
             value={value}
           />
         ))}
-        {customer.email && (
+        {customer.email && userRole > UserRole.PREPARATORS && (
           <Button
             variant="supplementary"
             iconLeft={<IconEnvelope />}

--- a/src/components/permits/PermitsDataTable.tsx
+++ b/src/components/permits/PermitsDataTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import useUserRole, { UserRole } from '../../api/useUserRole';
 import { OrderBy, PageInfo, Permit } from '../../types';
 import {
   formatAddress,
@@ -33,44 +34,53 @@ const PermitsDataTable = ({
   onRowClick,
   onExport,
 }: PermitsDataTableProps): React.ReactElement => {
+  const userRole = useUserRole();
   const { t, i18n } = useTranslation();
   const columns: Column<Permit>[] = [
-    {
-      name: t(`${T_PATH}.name`),
-      field: 'name',
-      selector: ({ customer }) => formatCustomerName(customer),
-      sortable: true,
-    },
-    {
-      name: 'Hetu',
-      field: 'nationalIdNumber',
-      selector: ({ customer }) => customer.nationalIdNumber,
-      sortable: true,
-    },
+    ...(userRole > UserRole.INSPECTORS
+      ? [
+          {
+            name: t(`${T_PATH}.name`),
+            field: 'name',
+            selector: ({ customer }) => formatCustomerName(customer),
+            sortable: true,
+          },
+          {
+            name: 'Hetu',
+            field: 'nationalIdNumber',
+            selector: ({ customer }) => customer.nationalIdNumber,
+            sortable: true,
+          },
+        ]
+      : []),
     {
       name: t(`${T_PATH}.registrationNumber`),
       field: 'registrationNumber',
       selector: row => row.vehicle.registrationNumber,
       sortable: true,
     },
-    {
-      name: t(`${T_PATH}.primaryAddress`),
-      field: 'primaryAddress',
-      selector: ({ customer }) =>
-        customer?.primaryAddress
-          ? formatAddress(customer.primaryAddress, i18n.language)
-          : '-',
-      sortable: true,
-    },
-    {
-      name: t(`${T_PATH}.otherAddress`),
-      field: 'otherAddress',
-      selector: ({ customer }) =>
-        customer?.otherAddress
-          ? formatAddress(customer.otherAddress, i18n.language)
-          : '-',
-      sortable: true,
-    },
+    ...(userRole > UserRole.INSPECTORS
+      ? [
+          {
+            name: t(`${T_PATH}.primaryAddress`),
+            field: 'primaryAddress',
+            selector: ({ customer }) =>
+              customer?.primaryAddress
+                ? formatAddress(customer.primaryAddress, i18n.language)
+                : '-',
+            sortable: true,
+          },
+          {
+            name: t(`${T_PATH}.otherAddress`),
+            field: 'otherAddress',
+            selector: ({ customer }) =>
+              customer?.otherAddress
+                ? formatAddress(customer.otherAddress, i18n.language)
+                : '-',
+            sortable: true,
+          },
+        ]
+      : []),
     {
       name: t(`${T_PATH}.zone`),
       field: 'parkingZone',

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -3,7 +3,8 @@ import { format, parse } from 'date-fns';
 import { Notification } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import OrdersDataTable from '../components/orders/OrdersDataTable';
 import OrdersSearch from '../components/orders/OrdersSearch';
@@ -81,6 +82,7 @@ const Orders = (): React.ReactElement => {
   const [searchParams, setSearchParams] = useSearchParams();
   const exportData = useExportData();
   const [errorMessage, setErrorMessage] = useState('');
+  const userRole = useUserRole();
 
   const { pageParam: page, setPageParam } = usePageParam();
   const { orderByParam: orderBy, setOrderBy } = useOrderByParam();
@@ -114,6 +116,10 @@ const Orders = (): React.ReactElement => {
       onError: error => setErrorMessage(error.message),
     }
   );
+
+  if (userRole < UserRole.PREPARATORS) {
+    return <Navigate to="/permits" />;
+  }
 
   const handleSearch = (newSearchParams: OrderSearchParams) => {
     setSearchParams(

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
 import ChangeLogs from '../components/common/ChangeLogs';
@@ -84,6 +85,7 @@ const PermitDetail = (): React.ReactElement => {
   const navigate = useNavigate();
   const exportData = useExportData();
   const params = useParams();
+  const userRole = useUserRole();
   const { t } = useTranslation();
   const [openEndPermitDialog, setOpenEndPermitDialog] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -141,36 +143,44 @@ const PermitDetail = (): React.ReactElement => {
           <CustomerInfo className={styles.customerInfo} permit={permitDetail} />
           <PermitInfo className={styles.permitInfo} permit={permitDetail} />
         </div>
-        <div className={styles.changeLogs}>
-          <div className={styles.changeLogsTitle}>
-            {t(`${T_PATH}.changeHistory`)}
+        {userRole > UserRole.INSPECTORS && (
+          <div className={styles.changeLogs}>
+            <div className={styles.changeLogsTitle}>
+              {t(`${T_PATH}.changeHistory`)}
+            </div>
+            <ChangeLogs changeLogs={changeLogs} />
           </div>
-          <ChangeLogs changeLogs={changeLogs} />
-        </div>
-        <div className={styles.footer}>
-          <Button
-            className={styles.actionButton}
-            iconLeft={<IconPenLine />}
-            onClick={() => navigate('edit')}>
-            {t(`${T_PATH}.edit`)}
-          </Button>
-          <div className={styles.spacer} />
-          <Button
-            className={styles.actionButton}
-            variant="secondary"
-            iconLeft={<IconDownload />}
-            onClick={handleExport}>
-            {t(`${T_PATH}.downloadPdf`)}
-          </Button>
-          <div className={styles.spacer} />
-          <Button
-            className={styles.cancelButton}
-            variant="secondary"
-            disabled={!canEndImmediately}
-            onClick={() => setOpenEndPermitDialog(true)}>
-            {t(`${T_PATH}.endPermit`)}
-          </Button>
-        </div>
+        )}
+        {userRole > UserRole.INSPECTORS && (
+          <div className={styles.footer}>
+            {userRole > UserRole.PREPARATORS && (
+              <Button
+                className={styles.actionButton}
+                iconLeft={<IconPenLine />}
+                onClick={() => navigate('edit')}>
+                {t(`${T_PATH}.edit`)}
+              </Button>
+            )}
+            <div className={styles.spacer} />
+            <Button
+              className={styles.actionButton}
+              variant="secondary"
+              iconLeft={<IconDownload />}
+              onClick={handleExport}>
+              {t(`${T_PATH}.downloadPdf`)}
+            </Button>
+            <div className={styles.spacer} />
+            {userRole > UserRole.PREPARATORS && (
+              <Button
+                className={styles.cancelButton}
+                variant="secondary"
+                disabled={!canEndImmediately}
+                onClick={() => setOpenEndPermitDialog(true)}>
+                {t(`${T_PATH}.endPermit`)}
+              </Button>
+            )}
+          </div>
+        )}
         <EndPermitDialog
           isOpen={openEndPermitDialog}
           currentPeriodEndTime={currentPeriodEndTime}

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
+import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import PermitsDataTable from '../components/permits/PermitsDataTable';
 import PermitsSearch from '../components/permits/PermitsSearch';
@@ -83,6 +84,7 @@ const PERMITS_QUERY = gql`
 const Permits = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const userRole = useUserRole();
   const [searchParams, setSearchParams] = useSearchParams();
   const exportData = useExportData();
   const statusParam = searchParams.get('status');
@@ -156,11 +158,13 @@ const Permits = (): React.ReactElement => {
     <div className={styles.container}>
       <div className={styles.header}>
         <h2>{t(`${T_PATH}.title`)}</h2>
-        <Button
-          iconLeft={<IconArrowRight />}
-          onClick={() => navigate('create')}>
-          {t(`${T_PATH}.createNewPermit`)}
-        </Button>
+        {userRole > UserRole.INSPECTORS && (
+          <Button
+            iconLeft={<IconArrowRight />}
+            onClick={() => navigate('create')}>
+            {t(`${T_PATH}.createNewPermit`)}
+          </Button>
+        )}
       </div>
       <PermitsSearch
         searchParams={permitSearchParams}

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -81,6 +81,44 @@ const PERMITS_QUERY = gql`
   }
 `;
 
+const LIMITED_PERMITS_QUERY = gql`
+  query GetPermits(
+    $pageInput: PageInput!
+    $orderBy: OrderByInput
+    $searchParams: PermitSearchParamsInput
+  ) {
+    limitedPermits(
+      pageInput: $pageInput
+      orderBy: $orderBy
+      searchParams: $searchParams
+    ) {
+      objects {
+        id
+        startTime
+        endTime
+        status
+        vehicle {
+          manufacturer
+          model
+          registrationNumber
+        }
+        parkingZone {
+          name
+        }
+      }
+      pageInfo {
+        numPages
+        page
+        next
+        prev
+        startIndex
+        endIndex
+        count
+      }
+    }
+  }
+`;
+
 const Permits = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -105,11 +143,14 @@ const Permits = (): React.ReactElement => {
   };
 
   const [getPermits, { loading, data, refetch }] =
-    useLazyQuery<PermitsQueryData>(PERMITS_QUERY, {
-      variables,
-      fetchPolicy: 'no-cache',
-      onError: error => setErrorMessage(error.message),
-    });
+    useLazyQuery<PermitsQueryData>(
+      userRole > UserRole.INSPECTORS ? PERMITS_QUERY : LIMITED_PERMITS_QUERY,
+      {
+        variables,
+        fetchPolicy: 'no-cache',
+        onError: error => setErrorMessage(error.message),
+      }
+    );
 
   const handleSearch = (newSearchParams: PermitSearchParams) => {
     setSearchParams(

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -8,7 +8,7 @@ import {
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import useUserRole, { UserRole } from '../api/useUserRole';
 import { makePrivate } from '../auth/utils';
 import RefundsDataTable from '../components/refunds/RefundsDataTable';
@@ -145,6 +145,10 @@ const Refunds = (): React.ReactElement => {
       onError: error => setErrorMessage(error.message),
     }
   );
+
+  if (userRole < UserRole.PREPARATORS) {
+    return <Navigate to="/permits" />;
+  }
 
   const canRequestForApproval =
     selectedRefunds &&

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -241,7 +241,7 @@ const Refunds = (): React.ReactElement => {
               }>
               {t(`${T_PATH}.requestForApproval`)}
             </Button>
-            {userRole >= UserRole.SANCTIONS_AND_RETURNS && (
+            {userRole >= UserRole.SANCTIONS_AND_REFUNDS && (
               <Button
                 disabled={!canAcceptRefunds}
                 className={styles.actionButton}


### PR DESCRIPTION
## Description

Role base access control admin UI for inspectors

## Context

### customer_service

- Only show permits tab

- Don’t show personal information in the table

- Ensure the downloadable .csv doesn’t include personal information

- Once a permit is opened:

  - In the “Customer information” column in the middle, only show “Parking zone” information
  
  - Hide “Change history” in the bottom
  
  - Hide all the buttons in the bottom, also the .pdf download button