### PR TITLE
PV-463: Fix orders CSV export

### DIFF
--- a/src/export/utils.ts
+++ b/src/export/utils.ts
@@ -2,7 +2,7 @@ import { getEnv } from '../utils';
 
 export function formatExportUrl(
   dataType: string,
-  searchParams: Record<string, string>
+  searchParams: Record<string, string> | URLSearchParams
 ): string {
   const baseUrl = getEnv('REACT_APP_PARKING_PERMITS_EXPORT_URL');
   const queryParams = new URLSearchParams(searchParams);

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -151,10 +151,7 @@ const Orders = (): React.ReactElement => {
   };
 
   const handleExport = () => {
-    const url = formatExportUrl('orders', {
-      ...orderBy,
-      page: page.toString(),
-    });
+    const url = formatExportUrl('orders', searchParams);
     exportData(url);
   };
 


### PR DESCRIPTION
## Description

Orders CSV export was missing the query parameters.

## Context

The orders CSV export doesn't work without search parameters... and was also missing the search parameters. This fixes it.

[PV-463](https://helsinkisolutionoffice.atlassian.net/browse/PV-463)

## How Has This Been Tested?

Manually, against the back-end changes.

## Manual Testing Instructions for Reviewers

Export a CSV in the orders view. Use the fixed back-end; some parameters do not work without it (i.e. any parameter with a multi-part name, like `contractTypes`)

