### PR TITLE
Clear name and address fields always when "Non-disclosure for personal safety"-checkbox is enabled

### DIFF
--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -121,7 +121,7 @@ const PersonalInfo = ({
           id="firstName"
           disabled={addressSecurityBan}
           label={t(`${T_PATH}.firstName`)}
-          value={firstName}
+          value={addressSecurityBan ? '' : firstName}
           onChange={e =>
             onUpdatePerson({ ...person, firstName: e.target.value })
           }
@@ -131,7 +131,7 @@ const PersonalInfo = ({
           disabled={addressSecurityBan}
           id="lastName"
           label={t(`${T_PATH}.lastName`)}
-          value={lastName}
+          value={addressSecurityBan ? '' : lastName}
           onChange={e =>
             onUpdatePerson({ ...person, lastName: e.target.value })
           }
@@ -142,7 +142,7 @@ const PersonalInfo = ({
           id="usePrimaryAddress"
           name="selectedAddress"
           label={t(`${T_PATH}.primaryAddress`)}
-          value={SelectedAddress.PRIMARY}
+          value={addressSecurityBan ? '' : SelectedAddress.PRIMARY}
           checked={selectedAddress === SelectedAddress.PRIMARY}
           onChange={() => {
             setSelectedAddress(SelectedAddress.PRIMARY);
@@ -156,7 +156,7 @@ const PersonalInfo = ({
             addressSecurityBan || selectedAddress !== SelectedAddress.PRIMARY
           }
           className={styles.addressSearch}
-          address={primaryAddress}
+          address={addressSecurityBan ? undefined : primaryAddress}
           onSelect={address => onSelectAddress('primaryAddress', address)}
         />
         <RadioButton
@@ -164,8 +164,8 @@ const PersonalInfo = ({
           className={styles.fieldItem}
           id="useOtherAddress"
           name="selectedAddress"
-          label={t(`${T_PATH}.otherAddress`)}
-          value={SelectedAddress.OTHER}
+          label={addressSecurityBan ? '' : t(`${T_PATH}.otherAddress`)}
+          value={addressSecurityBan ? '' : SelectedAddress.OTHER}
           checked={selectedAddress === SelectedAddress.OTHER}
           onChange={() => {
             setSelectedAddress(SelectedAddress.OTHER);
@@ -179,7 +179,7 @@ const PersonalInfo = ({
             addressSecurityBan || selectedAddress !== SelectedAddress.OTHER
           }
           className={styles.addressSearch}
-          address={otherAddress}
+          address={addressSecurityBan ? undefined : otherAddress}
           onSelect={address => onSelectAddress('otherAddress', address)}
         />
         <ZoneSelect

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,6 +229,7 @@ export function isValidForPriceCheck(permit: PermitInput): boolean {
     vehicle.powerType &&
     vehicle.euroClass &&
     vehicle.emissionType &&
+    vehicle.registrationNumber?.length &&
     Number.isInteger(vehicle.emission)
   );
   return (


### PR DESCRIPTION
## Description

Admin UI: Enabling "Non-disclosure for personal safety"-checkbox (Turvakielto) should clear name and address fields always.

## Context

Clear name and address fields always when "Non-disclosure for personal safety"-checkbox is enabled.

[PV-464](https://helsinkisolutionoffice.atlassian.net/browse/PV-464)

## How Has This Been Tested?

Login as any admin account and try to buy new permit. Input the value of some fields such as name and address then check 
`Non-disclosure for personal safety` checkbox. It disable the fields but doesn't clear its value.

## Manual Testing Instructions for Reviewers

Login as any admin account and try to buy new permit. Input the value of some fields such as name and address then check 
`Non-disclosure for personal safety` checkbox. It should now clear the the fields and disable it as well.

## Screenshots

![Nov-08-2022 08-36-23](https://user-images.githubusercontent.com/9328930/200494215-370fc063-405a-4fad-985d-3c4541107387.gif)
