### PR TITLE
Fix: Add missing subfields for vehicle powerType queries

### DIFF
--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -61,7 +61,10 @@ const VEHICLE_QUERY = gql`
       euroClass
       emission
       emissionType
-      powerType
+      powerType {
+        name
+        identifier
+      }
     }
   }
 `;

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -78,7 +78,10 @@ const VEHICLE_QUERY = gql`
       euroClass
       emission
       emissionType
-      powerType
+      powerType {
+        name
+        identifier
+      }
     }
   }
 `;

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -83,7 +83,10 @@ const PERMIT_DETAIL_QUERY = gql`
         euroClass
         emission
         emissionType
-        powerType
+        powerType {
+          name
+          identifier
+        }
       }
       parkingZone {
         name


### PR DESCRIPTION
## Description

Adds missing subfields for powerType field (in vehicle GQL queries)

## Context

Resident permit views do not work because of broken queries. Or more precisely, permit edit view just doesn't work and if creating a new permit, searching for a vehicle causes an error.

Related PR: https://github.com/City-of-Helsinki/parking-permits/pull/300 Doesn't work without this change.
