### PR TITLE
Fix inspectors not being able to search the permits

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,10 @@ export interface PermitsQueryData {
   permits: PagedPermits;
 }
 
+export interface LimitedPermitsQueryData {
+  limitedPermits: PagedPermits;
+}
+
 export interface PagedProducts {
   objects: Product[];
   pageInfo: PageInfo;


### PR DESCRIPTION
## Description

Inspectors uses limitedPermit query in order to search the permits. And therefore the process of extracting the data from the response should be updated depending on the query used.

[PV-478](https://helsinkisolutionoffice.atlassian.net/browse/PV-478)

## Manual Testing Instructions for Reviewers

Login as an inspectors and search the permits.

