### PR TITLE
Fix: Fix powerType in convertToVehicleInput

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,10 @@ export function convertToVehicleInput(vehicle: Vehicle): VehicleInput {
     euroClass,
     emission,
     emissionType,
-    powerType,
+    powerType: {
+      identifier: powerType.identifier,
+      name: powerType.name,
+    },
   };
 }
 


### PR DESCRIPTION
## Description

Initialize the `powerType` field in vehicle input correctly.
<!-- Describe your changes in detail -->

## Context

When editing a resident permit, if you don't change the vehicle power type, it sneaks a `__typename` field there. This causes errors.

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Edit a resident permit (after applying https://github.com/City-of-Helsinki/parking-permits/pull/307, editing a resident permit doesn't work at all before it)

