### PR TITLE
PV-350: Update parking permit history

### DIFF
--- a/src/components/common/ChangeLogs.tsx
+++ b/src/components/common/ChangeLogs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChangeLog, ChangeLogEvent } from '../../types';
+import { Link } from 'react-router-dom';
+import { ChangeLog, ChangeLogEvent, Order, Refund } from '../../types';
 import { formatDateTimeDisplay } from '../../utils';
 import { Column } from '../types';
 import DataTable from './DataTable';
@@ -12,31 +13,100 @@ export interface ChangeLogsProps {
 }
 
 const ChangeLogs = ({ changeLogs }: ChangeLogsProps): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('', { keyPrefix: T_PATH });
   const eventLabels = {
     [ChangeLogEvent.CREATED]: t('changelogEvent.CREATED'),
     [ChangeLogEvent.CHANGED]: t('changelogEvent.CHANGED'),
   };
+
+  const generateDescription = ({ key, context, relatedObject }: ChangeLog) => {
+    const changes = context?.changes;
+    return (
+      <>
+        {t(`descriptions.${key}`, { relatedObjectId: relatedObject?.id })}
+        {changes &&
+          Object.entries(changes).map(([fieldName, [oldValue, newValue]]) => {
+            const label = t(`fieldNames.${fieldName}`);
+            const value = `${oldValue} -> ${newValue}`;
+            return (
+              <div key={fieldName}>
+                {label}: {value}
+              </div>
+            );
+          })}
+      </>
+    );
+  };
+
   const columns: Column<ChangeLog>[] = [
     {
-      name: t(`${T_PATH}.createdAt`),
+      name: t('createdAt'),
       field: 'createdAt',
       selector: ({ createdAt }) => formatDateTimeDisplay(createdAt),
+      sortable: false,
     },
     {
-      name: t(`${T_PATH}.event`),
+      name: t('event'),
       field: 'event',
       selector: ({ event }) => (event ? eventLabels[event] : '-'),
+      sortable: false,
     },
     {
-      name: t(`${T_PATH}.description`),
-      field: 'description',
-      selector: ({ description }) => description || '-',
+      name: t('description'),
+      field: 'key',
+      selector: generateDescription,
+      sortable: false,
     },
     {
-      name: t(`${T_PATH}.createdBy`),
+      name: t('validityPeriod'),
+      field: 'validityPeriod',
+      selector: ({ validityPeriod }) =>
+        validityPeriod
+          ? `${formatDateTimeDisplay(
+              validityPeriod[0]
+            )} - ${formatDateTimeDisplay(validityPeriod[1])}`
+          : '',
+      sortable: false,
+    },
+    {
+      name: t('sum'),
+      field: 'sum',
+      selector: ({ relatedObject }) => {
+        switch (relatedObject?.__typename) {
+          case 'OrderNode':
+            return (relatedObject as Order).totalPrice;
+          case 'RefundNode':
+            return (relatedObject as Refund).amount;
+          default:
+            return '';
+        }
+      },
+      sortable: false,
+    },
+    {
+      name: t('paymentType'),
+      field: 'paymentType',
+      selector: ({ relatedObject }) => {
+        switch (relatedObject?.__typename) {
+          case 'OrderNode':
+            return t(`paymentTypes.${(relatedObject as Order).paymentType}`);
+          case 'RefundNode':
+            return (
+              <Link to={`/refunds/${relatedObject.id}`}>
+                {t('paymentTypes.REFUND')}
+              </Link>
+            );
+          default:
+            return '';
+        }
+      },
+      sortable: false,
+    },
+    {
+      name: t('createdBy'),
       field: 'createdBy',
       selector: ({ createdBy }) => createdBy || '-',
+      sortable: false,
     },
   ];
 

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -14,7 +14,43 @@
         "createdAt": "Muutosaika",
         "createdBy": "Muokkaaja",
         "description": "Selite",
-        "event": "Tapahtuma"
+        "event": "Tapahtuma",
+        "validityPeriod": "Tilauksen aikaväli",
+        "sum": "Summa, €",
+        "paymentType": "Maksutapa",
+        "paymentTypes": {
+          "CASHIER_PAYMENT": "Kassamaksu",
+          "ONLINE_PAYMENT": "Verkkomaksu",
+          "REFUND": "Palautus"
+        },
+        "paidAt": "Maksupäivä",
+        "fieldNames": {
+          "status": "Tila",
+          "customer__email": "Sähköpostiosoite",
+          "customer__first_name": "Etunimi",
+          "customer__last_name": "Sukunimi",
+          "customer__phone_number": "Puhelinnumero",
+          "customer__primary_address": "Osoite",
+          "customer__other_address": "Tilapäinen osoite",
+          "customer__zone": "Pysäköintialue",
+          "vehicle__registration_number": "Rekisterinumero"
+        },
+        "events": {
+          "update_permit": "Muokkaus",
+          "create_permit": "Tunnus luotu",
+          "end_permit": "Tunnus päätetty",
+          "renew_order": "Tunnus uusittu",
+          "create_order": "Tilaus luotu",
+          "create_refund": "Palautus luotu"
+        },
+        "descriptions": {
+          "update_permit": "Tunnuksen tietoja muokattu",
+          "create_permit": "Tunnus luotu",
+          "end_permit": "Tunnus päätetty",
+          "renew_order": "Tunnus uusittu",
+          "create_order": "Tilaus #{{relatedObjectId}} luotu tunnukselle",
+          "create_refund": "Palautus #{{relatedObjectId}} luotu tunnukselle"
+        }
       },
       "dataTable": {
         "downloadCsv": "Lataa listan tiedot (.csv)",

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -44,10 +44,27 @@ const PERMIT_DETAIL_QUERY = gql`
       description
       changeLogs {
         id
-        event
-        description
+        key
+        validityPeriod
         createdAt
         createdBy
+        context
+        contentType {
+          model
+        }
+        relatedObject {
+          __typename
+          ... on RefundNode {
+            id
+            amount
+          }
+          ... on OrderNode {
+            id
+            paidTime
+            paymentType
+            totalPrice
+          }
+        }
       }
       customer {
         firstName

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,12 +191,29 @@ export enum ChangeLogEvent {
   CHANGED = 'changed',
 }
 
+export interface ContentType {
+  model: string;
+  appLabel: string;
+}
+
+export interface ChangeLogContext {
+  changes: Record<string, Array<string>>;
+}
+
+export interface ChangeLogRelatedObject extends Refund, Order {
+  __typename: string;
+}
+
 export interface ChangeLog {
   id: string;
   event: ChangeLogEvent;
-  description: string;
+  key: string;
   createdAt: string;
   createdBy: string;
+  validityPeriod: Array<string>;
+  context: ChangeLogContext;
+  contentType: ContentType;
+  relatedObject: ChangeLogRelatedObject;
 }
 
 export interface TemporaryVehicle {
@@ -375,6 +392,7 @@ export interface Order {
   customer: Customer;
   paidTime: string;
   orderPermits: [Permit];
+  paymentType: string;
 }
 
 export interface PagedOrders {


### PR DESCRIPTION
## Description

Add new columns in parking permit history. Add support for the new parking permit event model. Not my best work, please pay attention to the code you're reviewing.

## Context

[PV-350](https://helsinkisolutionoffice.atlassian.net/browse/PV-350)

## How Has This Been Tested?

Some very little manual testing.

## Manual Testing Instructions for Reviewers

See if events created in the back-end end up in the permit detail page.

## Screenshots

![image](https://user-images.githubusercontent.com/2333857/203835617-3ae195b0-6c7c-4840-9d2c-2d5554113417.png)

