### PR TITLE
PV-350: Add temporary vehicles events, fix event column

### DIFF
--- a/src/components/common/ChangeLogs.tsx
+++ b/src/components/common/ChangeLogs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { ChangeLog, ChangeLogEvent, Order, Refund } from '../../types';
+import { ChangeLog, Order, Refund } from '../../types';
 import { formatDateTimeDisplay } from '../../utils';
 import { Column } from '../types';
 import DataTable from './DataTable';
@@ -14,10 +14,6 @@ export interface ChangeLogsProps {
 
 const ChangeLogs = ({ changeLogs }: ChangeLogsProps): React.ReactElement => {
   const { t } = useTranslation('', { keyPrefix: T_PATH });
-  const eventLabels = {
-    [ChangeLogEvent.CREATED]: t('changelogEvent.CREATED'),
-    [ChangeLogEvent.CHANGED]: t('changelogEvent.CHANGED'),
-  };
 
   const generateDescription = ({ key, context, relatedObject }: ChangeLog) => {
     const changes = context?.changes;
@@ -50,7 +46,7 @@ const ChangeLogs = ({ changeLogs }: ChangeLogsProps): React.ReactElement => {
     {
       name: t('event'),
       field: 'event',
-      selector: ({ event }) => (event ? eventLabels[event] : '-'),
+      selector: ({ key }) => t(`events.${key}`),
       sortable: false,
     },
     {

--- a/src/components/common/ChangeLogs.tsx
+++ b/src/components/common/ChangeLogs.tsx
@@ -23,7 +23,9 @@ const ChangeLogs = ({ changeLogs }: ChangeLogsProps): React.ReactElement => {
     const changes = context?.changes;
     return (
       <>
-        {t(`descriptions.${key}`, { relatedObjectId: relatedObject?.id })}
+        {t(`descriptions.${key}`, {
+          relatedObject,
+        })}
         {changes &&
           Object.entries(changes).map(([fieldName, [oldValue, newValue]]) => {
             const label = t(`fieldNames.${fieldName}`);

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -41,15 +41,19 @@
           "end_permit": "Tunnus päätetty",
           "renew_order": "Tunnus uusittu",
           "create_order": "Tilaus luotu",
-          "create_refund": "Palautus luotu"
+          "create_refund": "Palautus luotu",
+          "add_temporary_vehicle": "Muokkaus",
+          "remove_temporary_vehicle": "Muokkaus"
         },
         "descriptions": {
           "update_permit": "Tunnuksen tietoja muokattu",
           "create_permit": "Tunnus luotu",
           "end_permit": "Tunnus päätetty",
           "renew_order": "Tunnus uusittu",
-          "create_order": "Tilaus #{{relatedObjectId}} luotu tunnukselle",
-          "create_refund": "Palautus #{{relatedObjectId}} luotu tunnukselle"
+          "create_order": "Tilaus #{{relatedObject.id}} luotu tunnukselle",
+          "create_refund": "Palautus #{{relatedObject.id}} luotu tunnukselle",
+          "add_temporary_vehicle": "Tilapäinen ajoneuvo {{relatedObject.vehicle.registrationNumber}} lisätty tunnukseen",
+          "remove_temporary_vehicle": "Tilapäinen ajoneuvo {{relatedObject.vehicle.registrationNumber}} poistettu tunnuksesta"
         }
       },
       "dataTable": {

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -64,6 +64,12 @@ const PERMIT_DETAIL_QUERY = gql`
             paymentType
             totalPrice
           }
+          ... on TemporaryVehicleNode {
+            id
+            vehicle {
+              registrationNumber
+            }
+          }
         }
       }
       customer {


### PR DESCRIPTION
## Description

Add temporary vehicles events, fix event column

## Context

[PV-350](https://helsinkisolutionoffice.atlassian.net/browse/PV-350)

## How Has This Been Tested?

Manually.

## Screenshots

![image](https://user-images.githubusercontent.com/2333857/204552411-c8c608c9-3714-42b6-bd09-d4c5caf4c3b3.png)