### PR TITLE
Prevent future starting open-ended permit editing

### DIFF
--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -20,6 +20,7 @@ import { formatExportUrlPdf } from '../export/utils';
 import {
   MutationResponse,
   ParkingPermitStatus,
+  PermitContractType,
   PermitDetailData,
   PermitEndType,
 } from '../types';
@@ -204,7 +205,12 @@ const PermitDetail = (): React.ReactElement => {
       currentPeriodEndTime,
       canEndImmediately,
       canEndAfterCurrentPeriod,
+      startTime,
+      contractType,
     } = permitDetail;
+    const isOpenEndedPermitAndStarted =
+      contractType === PermitContractType.OPEN_ENDED &&
+      new Date(startTime) > new Date();
     content = (
       <>
         <Breadcrumbs>
@@ -265,7 +271,10 @@ const PermitDetail = (): React.ReactElement => {
                   <Button
                     className={styles.actionButton}
                     iconLeft={<IconPenLine />}
-                    disabled={status === ParkingPermitStatus.CLOSED}
+                    disabled={
+                      status === ParkingPermitStatus.CLOSED ||
+                      !!isOpenEndedPermitAndStarted
+                    }
                     onClick={() => navigate('edit')}>
                     {t(`${T_PATH}.edit`)}
                   </Button>


### PR DESCRIPTION
## Description

Prevent future starting open-ended permit editing

## Context

Fixes: [PV-513](https://helsinkisolutionoffice.atlassian.net/browse/PV-513)

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Have future starting open-ended permit and see if the permit "Edit"-button is disabled.
Future starting fixed-period permits and already started open-ended permits should still be editable.

## Screenshots

![prevent-open-ended-permit-edit](https://user-images.githubusercontent.com/2784933/205220766-4a7d1385-ea0f-43d7-8421-e24a4efe10ca.png)

