### PR TITLE
Update SuperAdmin form buttons

### DIFF
--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -10,6 +10,7 @@ interface ConfirmDialogProps {
   cancelLabel: string;
   onCancel: () => void;
   onConfirm: () => void;
+  isDeleteConfirmation?: boolean;
 }
 
 const DIALOG_ID = 'confirm-dialog';
@@ -25,6 +26,7 @@ const ConfirmDialog = ({
   cancelLabel,
   onConfirm,
   onCancel,
+  isDeleteConfirmation,
 }: ConfirmDialogProps): React.ReactElement => (
   <Dialog
     id={DIALOG_ID}
@@ -37,7 +39,11 @@ const ConfirmDialog = ({
       {secondaryMessage && <p>{secondaryMessage}</p>}
     </Dialog.Content>
     <Dialog.ActionButtons>
-      <Button onClick={() => onConfirm()}>{confirmLabel}</Button>
+      <Button
+        variant={isDeleteConfirmation ? 'danger' : 'primary'}
+        onClick={() => onConfirm()}>
+        {confirmLabel}
+      </Button>
       <Button variant="secondary" onClick={() => onCancel()}>
         {cancelLabel}
       </Button>

--- a/src/components/superAdmin/addresses/AddressForm.module.scss
+++ b/src/components/superAdmin/addresses/AddressForm.module.scss
@@ -41,4 +41,8 @@
   .submit {
     margin-right: $spacing-s;
   }
+
+  .delete {
+    margin-right: $spacing-s;
+  }
 }

--- a/src/components/superAdmin/addresses/AddressForm.tsx
+++ b/src/components/superAdmin/addresses/AddressForm.tsx
@@ -28,6 +28,7 @@ interface AddressFormProps {
   address?: Address;
   onSubmit: (address: Address) => void;
   onDelete?: () => void;
+  onCancel: () => void;
 }
 
 const AddressForm = ({
@@ -35,6 +36,7 @@ const AddressForm = ({
   address,
   onSubmit,
   onDelete,
+  onCancel,
 }: AddressFormProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
   const [
@@ -229,6 +231,12 @@ const AddressForm = ({
                   {t(`${T_PATH}.delete`)}
                 </Button>
               )}
+              <Button
+                className={styles.cancel}
+                variant="secondary"
+                onClick={() => onCancel()}>
+                {t(`${T_PATH}.cancel`)}
+              </Button>
             </div>
           </form>
         )}

--- a/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.module.scss
+++ b/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.module.scss
@@ -33,4 +33,8 @@
   .submit {
     margin-right: $spacing-s;
   }
+
+  .delete {
+    margin-right: $spacing-s;
+  }
 }

--- a/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.tsx
+++ b/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.tsx
@@ -18,6 +18,7 @@ interface LowEmissionCriterionFormProps {
   criterion?: LowEmissionCriterion;
   onSubmit: (criterion: LowEmissionCriterion) => void;
   onDelete?: () => void;
+  onCancel: () => void;
 }
 
 const LowEmissionCriterionForm = ({
@@ -25,6 +26,7 @@ const LowEmissionCriterionForm = ({
   criterion,
   onSubmit,
   onDelete,
+  onCancel,
 }: LowEmissionCriterionFormProps): React.ReactElement => {
   const { t } = useTranslation();
   const initialValues = criterion
@@ -164,6 +166,12 @@ const LowEmissionCriterionForm = ({
                   {t(`${T_PATH}.delete`)}
                 </Button>
               )}
+              <Button
+                className={styles.cancel}
+                variant="secondary"
+                onClick={() => onCancel()}>
+                {t(`${T_PATH}.cancel`)}
+              </Button>
             </div>
           </form>
         )}

--- a/src/components/superAdmin/products/ProductForm.module.scss
+++ b/src/components/superAdmin/products/ProductForm.module.scss
@@ -20,4 +20,8 @@
   .submit {
     margin-right: $spacing-s;
   }
+
+  .delete {
+    margin-right: $spacing-s;
+  }
 }

--- a/src/components/superAdmin/products/ProductForm.tsx
+++ b/src/components/superAdmin/products/ProductForm.tsx
@@ -35,6 +35,7 @@ interface ProductFormProps {
   product?: ProductInput;
   onSubmit: (product: ProductInput) => void;
   onDelete?: () => void;
+  onCancel: () => void;
 }
 
 const ProductForm = ({
@@ -42,6 +43,7 @@ const ProductForm = ({
   product,
   onSubmit,
   onDelete,
+  onCancel,
 }: ProductFormProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
   const { data } = useQuery<{ zones: ParkingZone[] }>(ZONES_QUERY);
@@ -243,6 +245,12 @@ const ProductForm = ({
                   {t(`${T_PATH}.delete`)}
                 </Button>
               )}
+              <Button
+                className={styles.cancel}
+                variant="secondary"
+                onClick={() => onCancel()}>
+                {t(`${T_PATH}.cancel`)}
+              </Button>
             </div>
           </form>
         )}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -291,6 +291,7 @@
           "postalCode": "Postal code",
           "postalCode5Digits": "Postal code should have 5 digits",
           "save": "Save",
+          "cancel": "Cancel",
           "selectLocation": "Please select a location",
           "streetName": "Street name",
           "streetNameSv": "Street name (sv)",
@@ -324,6 +325,7 @@
           "nedcMaxEmissionLimit": "NEDC maximum emission limit",
           "powerType": "Power type",
           "save": "Save",
+          "cancel": "Cancel",
           "startDate": "Start date",
           "validPeriod": "Valid period",
           "wltpMaxEmissionLimit": "WLTP maximum emission limit"
@@ -347,6 +349,7 @@
           "productPrice": "Product price",
           "productType": "Product type",
           "save": "Save",
+          "cancel": "Cancel",
           "startDate": "Start date",
           "unit": "Unit",
           "validPeriod": "Valid period",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -332,6 +332,7 @@
           "postalCode": "Postinumero",
           "postalCode5Digits": "Postinumerossa tulee olla 5 numeroa",
           "save": "Tallenna",
+          "cancel": "Peruuta",
           "selectLocation": "Valitse sijainti",
           "streetName": "Kadun nimi",
           "streetNameSv": "Kadun nimi (sv)",
@@ -365,6 +366,7 @@
           "nedcMaxEmissionLimit": "NEDC-maksimipäästöraja",
           "powerType": "Käyttövoima",
           "save": "Tallenna",
+          "cancel": "Peruuta",
           "startDate": "Pvm alkaen",
           "validPeriod": "Voimassaoloaika",
           "wltpMaxEmissionLimit": "WLTP-maksimipäästöraja"
@@ -388,6 +390,7 @@
           "productPrice": "Tuotteen hinta",
           "productType": "Tuotetyyppi",
           "save": "Tallenna",
+          "cancel": "Peruuta",
           "startDate": "Pvm alkaen",
           "unit": "Jakso",
           "validPeriod": "Voimassaoloaika",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -262,6 +262,7 @@
           "postalCode": "Postnummer",
           "postalCode5Digits": "Postnummer ska ha 5 siffror",
           "save": "Spara",
+          "cancel": "Avbryt",
           "selectLocation": "Välj en plats",
           "streetName": "Gatunamn",
           "streetNameSv": "Gatunamn (sv)",
@@ -295,6 +296,7 @@
           "nedcMaxEmissionLimit": "NEDC maximala utsläppsgräns",
           "powerType": "Strömtyp",
           "save": "Spara",
+          "cancel": "Avbryt",
           "startDate": "Startdatum",
           "validPeriod": "Giltighetsperiod",
           "wltpMaxEmissionLimit": "WLTP maximala utsläppsgräns"
@@ -318,6 +320,7 @@
           "productPrice": "Produktpris",
           "productType": "Produkttyp",
           "save": "Spara",
+          "cancel": "Avbryt",
           "startDate": "Startdatum",
           "unit": "Enhet",
           "validPeriod": "Giltighetsperiod",

--- a/src/pages/superAdmin/addresses/CreateAddress.tsx
+++ b/src/pages/superAdmin/addresses/CreateAddress.tsx
@@ -22,10 +22,11 @@ const CreateAddress = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
+  const basePath = '/admin/addresses';
   const [createAddress] = useMutation<MutationResponse>(
     CREATE_ADDRESS_MUTATION,
     {
-      onCompleted: () => navigate('/admin/addresses'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -36,6 +37,7 @@ const CreateAddress = (): React.ReactElement => {
         <AddressForm
           onSubmit={address => createAddress({ variables: { address } })}
           className={styles.addressForm}
+          onCancel={() => navigate(basePath)}
         />
       </div>
       {errorMessage && (

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -54,6 +54,7 @@ const EditAddress = (): React.ReactElement => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const { id: addressId } = useParams();
   const variables = { addressId };
+  const basePath = '/admin/addresses';
   const { loading, data } = useQuery<{ address: Address }>(ADDRESS_QUERY, {
     variables,
     fetchPolicy: 'no-cache',
@@ -62,14 +63,14 @@ const EditAddress = (): React.ReactElement => {
   const [updateAddress] = useMutation<MutationResponse>(
     UPDATE_ADDRESS_MUTATION,
     {
-      onCompleted: () => navigate('/admin/addresses'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
   const [deleteAddress] = useMutation<MutationResponse>(
     DELETE_ADDRESS_MUTATION,
     {
-      onCompleted: () => navigate('/admin/addresses'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -89,6 +90,7 @@ const EditAddress = (): React.ReactElement => {
               updateAddress({ variables: { addressId, address } })
             }
             onDelete={() => setIsConfirmDialogOpen(true)}
+            onCancel={() => navigate(basePath)}
             address={data.address}
             className={styles.addressForm}
           />
@@ -105,6 +107,7 @@ const EditAddress = (): React.ReactElement => {
           handleDeleteAddress();
         }}
         onCancel={() => setIsConfirmDialogOpen(false)}
+        isDeleteConfirmation
       />
       {errorMessage && (
         <Notification

--- a/src/pages/superAdmin/lowEmissionCriteria/CreateLowEmissionCriterion.tsx
+++ b/src/pages/superAdmin/lowEmissionCriteria/CreateLowEmissionCriterion.tsx
@@ -22,10 +22,11 @@ const CreateLowEmissionCriterion = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
+  const basePath = '/admin/lowEmissionCriteria';
   const [createCriterion] = useMutation<MutationResponse>(
     CREATE_LOW_EMISSION_CRITERION_MUTATION,
     {
-      onCompleted: () => navigate('/admin/lowEmissionCriteria'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -35,6 +36,7 @@ const CreateLowEmissionCriterion = (): React.ReactElement => {
       <div className={styles.content}>
         <LowEmissionCriterionForm
           onSubmit={criterion => createCriterion({ variables: { criterion } })}
+          onCancel={() => navigate(basePath)}
         />
       </div>
       {errorMessage && (

--- a/src/pages/superAdmin/lowEmissionCriteria/EditLowEmissionCriterion.tsx
+++ b/src/pages/superAdmin/lowEmissionCriteria/EditLowEmissionCriterion.tsx
@@ -53,6 +53,7 @@ const EditLowEmissionCriterion = (): React.ReactElement => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const { id: criterionId } = useParams();
   const variables = { criterionId };
+  const basePath = '/admin/lowEmissionCriteria';
   const { loading, data } = useQuery<{
     lowEmissionCriterion: LowEmissionCriterion;
   }>(LOW_EMISSION_CRITERION_QUERY, {
@@ -63,14 +64,14 @@ const EditLowEmissionCriterion = (): React.ReactElement => {
   const [updateCriterion] = useMutation<MutationResponse>(
     UPDATE_LOW_EMISSION_CRITERION_MUTATION,
     {
-      onCompleted: () => navigate('/admin/lowEmissionCriteria'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
   const [deleteCriterion] = useMutation<MutationResponse>(
     DELETE_LOW_EMISSION_CRITERION_MUTATION,
     {
-      onCompleted: () => navigate('/admin/lowEmissionCriteria'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -92,6 +93,7 @@ const EditLowEmissionCriterion = (): React.ReactElement => {
             updateCriterion({ variables: { criterionId, criterion } })
           }
           onDelete={() => setIsConfirmDialogOpen(true)}
+          onCancel={() => navigate(basePath)}
           criterion={data.lowEmissionCriterion}
         />
       </div>
@@ -106,6 +108,7 @@ const EditLowEmissionCriterion = (): React.ReactElement => {
           handleDeleteCriterion();
         }}
         onCancel={() => setIsConfirmDialogOpen(false)}
+        isDeleteConfirmation
       />
       {errorMessage && (
         <Notification

--- a/src/pages/superAdmin/products/CreateProduct.tsx
+++ b/src/pages/superAdmin/products/CreateProduct.tsx
@@ -22,10 +22,11 @@ const Products = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
+  const basePath = '/admin/products';
   const [createProduct] = useMutation<MutationResponse>(
     CREATE_PRODUCT_MUTATION,
     {
-      onCompleted: () => navigate('/admin/products'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -36,6 +37,7 @@ const Products = (): React.ReactElement => {
         <ProductForm
           onSubmit={product => createProduct({ variables: { product } })}
           className={styles.productForm}
+          onCancel={() => navigate(basePath)}
         />
       </div>
       {errorMessage && (

--- a/src/pages/superAdmin/products/EditProduct.tsx
+++ b/src/pages/superAdmin/products/EditProduct.tsx
@@ -54,6 +54,7 @@ const Products = (): React.ReactElement => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const { id: productId } = useParams();
   const variables = { productId };
+  const basePath = '/admin/products';
   const { loading, data } = useQuery<{ product: Product }>(PRODUCT_QUERY, {
     variables,
     fetchPolicy: 'no-cache',
@@ -62,14 +63,14 @@ const Products = (): React.ReactElement => {
   const [updateProduct] = useMutation<MutationResponse>(
     UPDATE_PRODUCT_MUTATION,
     {
-      onCompleted: () => navigate('/admin/products'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
   const [deleteProduct] = useMutation<MutationResponse>(
     DELETE_PRODUCT_MUTATION,
     {
-      onCompleted: () => navigate('/admin/products'),
+      onCompleted: () => navigate(basePath),
       onError: e => setErrorMessage(e.message),
     }
   );
@@ -89,6 +90,7 @@ const Products = (): React.ReactElement => {
               updateProduct({ variables: { productId, product } })
             }
             onDelete={() => setIsConfirmDialogOpen(true)}
+            onCancel={() => navigate(basePath)}
             product={data.product}
             className={styles.productForm}
           />
@@ -105,6 +107,7 @@ const Products = (): React.ReactElement => {
           handleDeleteProduct();
         }}
         onCancel={() => setIsConfirmDialogOpen(false)}
+        isDeleteConfirmation
       />
       {errorMessage && (
         <Notification


### PR DESCRIPTION
## Description

Update SuperAdmin form buttons. Add cancel-button to address-, product- and lowemissioncriteria-forms. Also use red-colored `danger`-variant buttons in delete-confirmation dialogs in those entity deletion cases.

## Context

Fixes: [PV-422](https://helsinkisolutionoffice.atlassian.net/browse/PV-422)

## How Has This Been Tested?

Locally.

## Screenshots

![address-form-buttons](https://user-images.githubusercontent.com/2784933/206517564-b5389786-52d2-4735-a4e3-d63dc59c648b.png)

![address-confirm-delete](https://user-images.githubusercontent.com/2784933/206518115-df2b6fa5-e68d-41c4-905b-530e25565ace.png)

![lowemissioncriteria-form-buttons](https://user-images.githubusercontent.com/2784933/206517615-7e2fb6bd-4e35-4b8b-b812-1fe78f3d383b.png)

![lowemissioncriteria-confirm-delete](https://user-images.githubusercontent.com/2784933/206517629-7d721cca-2c0e-40bf-a223-f280f27aa3cf.png)

![product-form-buttons](https://user-images.githubusercontent.com/2784933/206518362-a1987b66-2df4-4697-8df2-758b72184dd2.png)

![product-confirm-delete](https://user-images.githubusercontent.com/2784933/206518381-f1c4ce0e-7b54-4164-b0fb-4ba46edd6adb.png)

