### PR TITLE
PV-519: Show the current period end time for open-ended permits

### DIFF
--- a/src/components/permitDetail/PermitInfo.tsx
+++ b/src/components/permitDetail/PermitInfo.tsx
@@ -35,8 +35,12 @@ const PermitInfo = ({
     endTimeValue = formatDateTimeDisplay(new Date());
   } else if (endType === PermitEndType.AFTER_CURRENT_PERIOD) {
     endTimeValue = formatDateTimeDisplay(currentPeriodEndTime);
+  } else if (endTime) {
+    endTimeValue = formatDateTimeDisplay(endTime);
+  } else if (currentPeriodEndTime) {
+    endTimeValue = formatDateTimeDisplay(currentPeriodEndTime);
   } else {
-    endTimeValue = endTime ? formatDateTimeDisplay(endTime) : '-';
+    endTimeValue = '-';
   }
   const contractTypeLabelMapping = {
     FIXED_PERIOD: t('contractType.fixedPeriod'),


### PR DESCRIPTION
## Description

Show the current period end time for open-ended permits.

## Context

[PV-519](https://helsinkisolutionoffice.atlassian.net/browse/PV-519)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Check that an ongoing open-ended permit has the correct end time (i.e. the end of the current 1-month period)

## Screenshots

![image](https://user-images.githubusercontent.com/2333857/211814041-b26b7efc-4708-40bd-8af4-27e163b89874.png)


[PV-519]: https://helsinkisolutionoffice.atlassian.net/browse/PV-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ