### PR TITLE
Add apartment support for addresses

### DIFF
--- a/src/components/common/AddressSearch.tsx
+++ b/src/components/common/AddressSearch.tsx
@@ -70,7 +70,9 @@ const AddressSearch = ({
           .then(() =>
             (data?.addressSearch || [])
               .map((_address: Address) => ({
-                label: formatAddress(_address, 'fi'),
+                label: formatAddress(_address, 'fi', {
+                  withPostalCode: true,
+                }),
                 address: _address,
               }))
               .sort((a, b) => a.label.localeCompare(b.label))

--- a/src/components/permitDetail/CustomerInfo.tsx
+++ b/src/components/permitDetail/CustomerInfo.tsx
@@ -31,13 +31,17 @@ const CustomerInfo = ({
           {
             label: t(`${T_PATH}.primaryAddress`),
             value: customer?.primaryAddress
-              ? formatAddress(customer.primaryAddress, i18n.language)
+              ? formatAddress(customer.primaryAddress, i18n.language, {
+                  addressApartment: customer.primaryAddressApartment,
+                })
               : '-',
           },
           {
             label: t(`${T_PATH}.otherAddress`),
             value: customer?.otherAddress
-              ? formatAddress(customer.otherAddress, i18n.language)
+              ? formatAddress(customer.otherAddress, i18n.language, {
+                  addressApartment: customer.otherAddressApartment,
+                })
               : '-',
           },
         ]),

--- a/src/components/permitDetail/PermitInfo.tsx
+++ b/src/components/permitDetail/PermitInfo.tsx
@@ -35,6 +35,7 @@ const PermitInfo = ({
     primaryVehicle,
     parkingZone,
     address,
+    addressApartment,
   } = permit;
   let endTimeValue = '';
   if (endType === PermitEndType.IMMEDIATELY) {
@@ -81,7 +82,9 @@ const PermitInfo = ({
     },
     {
       label: t(`${T_PATH}.address`),
-      value: formatAddress(address, i18n.language),
+      value: formatAddress(address, i18n.language, {
+        addressApartment,
+      }),
     },
     {
       label: t(`${T_PATH}.parkingZone`),

--- a/src/components/permits/PermitsDataTable.tsx
+++ b/src/components/permits/PermitsDataTable.tsx
@@ -67,7 +67,10 @@ const PermitsDataTable = ({
             field: 'primaryAddress',
             selector: ({ address, customer }) =>
               isPermitAddress(address, customer?.primaryAddress)
-                ? formatAddress(address, i18n.language)
+                ? formatAddress(address, i18n.language, {
+                    addressApartment: customer.primaryAddressApartment,
+                    withPostalCode: true,
+                  })
                 : '-',
             sortable: true,
           },
@@ -76,7 +79,10 @@ const PermitsDataTable = ({
             field: 'otherAddress',
             selector: ({ address, customer }) =>
               isPermitAddress(address, customer?.otherAddress)
-                ? formatAddress(address, i18n.language)
+                ? formatAddress(address, i18n.language, {
+                    addressApartment: customer.otherAddressApartment,
+                    withPostalCode: true,
+                  })
                 : '-',
             sortable: true,
           },

--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -32,6 +32,7 @@ const CUSTOMER_QUERY = gql`
           labelSv
         }
       }
+      primaryAddressApartment
       otherAddress {
         city
         citySv
@@ -44,6 +45,7 @@ const CUSTOMER_QUERY = gql`
           labelSv
         }
       }
+      otherAddressApartment
     }
   }
 `;

--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -47,7 +47,9 @@ const PersonalInfo = ({
   const { t, i18n } = useTranslation();
   const {
     primaryAddress,
+    primaryAddressApartment,
     otherAddress,
+    otherAddressApartment,
     nationalIdNumber,
     addressSecurityBan,
     firstName,
@@ -188,6 +190,35 @@ const PersonalInfo = ({
         <AddressSearch
           className={styles.addressSearch}
           onSelect={address => onSelectAddress(selectedAddress, address)}
+        />
+        <TextInput
+          className={styles.fieldItem}
+          id="addressApartment"
+          label={t(`${T_PATH}.addressApartment`)}
+          value={
+            selectedAddress === SelectedAddress.PRIMARY
+              ? primaryAddressApartment
+              : otherAddressApartment
+          }
+          onChange={e => {
+            if (selectedAddress === SelectedAddress.PRIMARY) {
+              onUpdatePermit({
+                addressApartment: e.target.value,
+                customer: {
+                  ...person,
+                  primaryAddressApartment: e.target.value,
+                },
+              });
+            } else {
+              onUpdatePermit({
+                addressApartment: e.target.value,
+                customer: {
+                  ...person,
+                  otherAddressApartment: e.target.value,
+                },
+              });
+            }
+          }}
         />
         <ZoneSelect
           required

--- a/src/components/superAdmin/addresses/AddressForm.tsx
+++ b/src/components/superAdmin/addresses/AddressForm.tsx
@@ -64,8 +64,8 @@ const AddressForm = ({
         streetNameSv: '',
         streetNumber: '',
         postalCode: '',
-        city: 'Helsinki',
-        citySv: 'Helsingfors',
+        city: 'HELSINKI',
+        citySv: 'HELSINGFORS',
         location: HELSINKI_LOCATION,
       };
   const validationSchema = Yup.object().shape({
@@ -173,7 +173,7 @@ const AddressForm = ({
                         id={field.name}
                         className={styles.field}
                         label={t(`${T_PATH}.city`)}
-                        value="Helsinki"
+                        value="HELSINKI"
                       />
                     )}
                   </Field>
@@ -184,7 +184,7 @@ const AddressForm = ({
                         id={field.name}
                         className={styles.field}
                         label={t(`${T_PATH}.citySv`)}
-                        value="Helsingfors"
+                        value="HELSINGFORS"
                       />
                     )}
                   </Field>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -261,6 +261,7 @@
         "personalInfo": "Personal Information",
         "phoneNumber": "Phone number",
         "primaryAddress": "Permanent address",
+        "addressApartment": "Apartment",
         "search": "Search",
         "zone": "Zone"
       },

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -304,6 +304,7 @@
         "personalInfo": "Henkilötiedot",
         "phoneNumber": "Puhelinnumero",
         "primaryAddress": "Vakituinen osoite",
+        "addressApartment": "Huoneisto",
         "search": "Hae",
         "zone": "Alue"
       },

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -231,6 +231,7 @@
         "personalInfo": "Personlig information",
         "phoneNumber": "Telefonnummer",
         "primaryAddress": "Permanent adress",
+        "addressApartment": "Lägenhet",
         "search": "Sök",
         "zone": "Zon"
       },

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -53,6 +53,7 @@ const CUSTOMER_QUERY = gql`
           labelSv
         }
       }
+      primaryAddressApartment
       otherAddress {
         id
         city
@@ -67,6 +68,7 @@ const CUSTOMER_QUERY = gql`
           labelSv
         }
       }
+      otherAddressApartment
       activePermits {
         id
         primaryVehicle

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -53,6 +53,7 @@ const PERMIT_DETAIL_QUERY = gql`
           name
         }
       }
+      addressApartment
       customer {
         firstName
         lastName
@@ -76,6 +77,7 @@ const PERMIT_DETAIL_QUERY = gql`
             labelSv
           }
         }
+        primaryAddressApartment
         otherAddress {
           id
           streetName
@@ -91,6 +93,7 @@ const PERMIT_DETAIL_QUERY = gql`
             labelSv
           }
         }
+        otherAddressApartment
         activePermits {
           id
           primaryVehicle

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -35,6 +35,7 @@ const PERMIT_DETAIL_QUERY = gql`
       monthCount
       monthsLeft
       totalRefundAmount
+      addressApartment
       customer {
         firstName
         lastName
@@ -49,6 +50,7 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        primaryAddressApartment
         otherAddress {
           streetName
           streetNameSv
@@ -57,6 +59,7 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        otherAddressApartment
       }
       vehicle {
         manufacturer

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -52,6 +52,7 @@ const PERMIT_DETAIL_QUERY = gql`
         citySv
         postalCode
       }
+      addressApartment
       changeLogs {
         id
         key
@@ -96,6 +97,7 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        primaryAddressApartment
         otherAddress {
           streetName
           streetNameSv
@@ -104,6 +106,7 @@ const PERMIT_DETAIL_QUERY = gql`
           citySv
           postalCode
         }
+        otherAddressApartment
       }
       activeTemporaryVehicle {
         id

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -62,6 +62,7 @@ const PERMITS_QUERY = gql`
             citySv
             postalCode
           }
+          primaryAddressApartment
           otherAddress {
             streetName
             streetNameSv
@@ -70,6 +71,7 @@ const PERMITS_QUERY = gql`
             citySv
             postalCode
           }
+          otherAddressApartment
         }
         vehicle {
           manufacturer

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,9 @@ export interface Customer {
   lastName: string;
   nationalIdNumber: string;
   primaryAddress?: Address;
+  primaryAddressApartment?: string;
   otherAddress?: Address;
+  otherAddressApartment?: string;
   email: string;
   phoneNumber: string;
   zone?: ParkingZone;
@@ -243,6 +245,7 @@ export interface TemporaryVehicle {
 export interface PermitDetail {
   id?: number;
   address: Address;
+  addressApartment: string;
   customer: Customer;
   vehicle: Vehicle;
   activeTemporaryVehicle: TemporaryVehicle;
@@ -274,7 +277,9 @@ export interface CustomerInput {
   lastName: string;
   nationalIdNumber: string;
   primaryAddress?: Address;
+  primaryAddressApartment?: string;
   otherAddress?: Address;
+  otherAddressApartment?: string;
   zone?: string;
   email: string;
   phoneNumber: string;
@@ -292,6 +297,7 @@ export interface PermitInput {
   description: string;
   zone: string | undefined;
   address: Address | undefined;
+  addressApartment: string;
 }
 
 export interface PageInfo {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,10 @@ export function formatPeriod(count: number, unit: string): string {
 export function formatAddress(
   address: Address | undefined,
   lang: string,
-  options?: { withPostalCode?: boolean }
+  options?: {
+    withPostalCode?: boolean;
+    addressApartment?: string;
+  }
 ): string {
   if (!address) {
     return '-';
@@ -46,10 +49,15 @@ export function formatAddress(
   if (options?.withPostalCode) {
     postalCode = `${address.postalCode} `;
   }
-  if (lang === 'sv') {
-    return `${streetNameSv} ${streetNumber}, ${postalCode}${citySv}`;
+
+  let addressApartmentStr = '';
+  if (options?.addressApartment && options.addressApartment.length > 0) {
+    addressApartmentStr = ` ${options.addressApartment}`;
   }
-  return `${streetName} ${streetNumber}, ${postalCode}${city}`;
+  if (lang === 'sv') {
+    return `${streetNameSv} ${streetNumber}${addressApartmentStr}, ${postalCode}${citySv}`;
+  }
+  return `${streetName} ${streetNumber}${addressApartmentStr}, ${postalCode}${city}`;
 }
 
 export function isPermitAddress(
@@ -214,7 +222,9 @@ export function convertToCustomerInput(customer: Customer): CustomerInput {
     lastName,
     nationalIdNumber,
     primaryAddress,
+    primaryAddressApartment,
     otherAddress,
+    otherAddressApartment,
     email,
     phoneNumber,
     addressSecurityBan,
@@ -231,7 +241,9 @@ export function convertToCustomerInput(customer: Customer): CustomerInput {
     lastName,
     nationalIdNumber,
     primaryAddress: primaryAddressInput,
+    primaryAddressApartment,
     otherAddress: otherAddressInput,
+    otherAddressApartment,
     email,
     phoneNumber,
     addressSecurityBan,
@@ -249,6 +261,7 @@ export function convertToPermitInput(permit: PermitDetail): PermitInput {
     monthCount,
     description,
     address,
+    addressApartment,
     parkingZone,
   } = permit;
   const vehicleInput = convertToVehicleInput(vehicle);
@@ -263,6 +276,7 @@ export function convertToPermitInput(permit: PermitDetail): PermitInput {
     description,
     zone: parkingZone?.name || address?.zone?.name,
     address: convertAddressToAddressInput(address),
+    addressApartment,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function formatAddress(
   }
 
   let addressApartmentStr = '';
-  if (options?.addressApartment && options.addressApartment.length > 0) {
+  if (options?.addressApartment) {
     addressApartmentStr = ` ${options.addressApartment}`;
   }
   if (lang === 'sv') {


### PR DESCRIPTION
## Description

Add apartment support for addresses.

## Context

[PV-591](https://helsinkisolutionoffice.atlassian.net/browse/PV-591)

## How Has This Been Tested?

Manually by creating new permit with apartment details and editing existing permit apartment details.

## Manual Testing Instructions for Reviewers

Test cases:
1. Create new permit with apartment details
2. Edit existing permit apartment details
3. Search permits and observe that permit has apartment details in address
4. Search orders and observe that permit has apartment details in address
5. Open permit details form and observe that permit has apartment details in address (both customer primary or other address details and permit details)
6. Make CSV-export for permits
7. Make CSV-export for orders
8. Make PDF-export for permit

## Screenshots
![permit-details](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/b415941e-87bc-4c2d-b29f-2fc3cfbd22bc)
![permits-listing](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/b5928260-11c2-40f7-80b1-87374eb0830c)
![address](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/98f06ef8-9ab8-4040-b91e-69d1ea1d4ec6)



[PV-591]: https://helsinkisolutionoffice.atlassian.net/browse/PV-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ