### PR TITLE
Add browser reload to user info poll on session timeout

### DIFF
--- a/src/auth/oidc-react.ts
+++ b/src/auth/oidc-react.ts
@@ -333,6 +333,8 @@ export function createOidcClient(): Client {
           returnedHttpStatus === HttpStatusCode.UNAUTHORIZED)
       ) {
         setError({ type: ClientError.UNEXPECTED_AUTH_CHANGE, message: '' });
+        // reload page to force redirect to login
+        window.location.reload();
         return { keepPolling: false };
       }
       return { keepPolling: isAuthenticated() };


### PR DESCRIPTION
## Description

The polling runs every few minutes and fetches the latest user info from the OIDC server. If the token has expired (based on the `expired_at` value) the server will return a 401. A 403 may be returned if some other server setting has changed e.g. the user has had permissions removed.

In this case, we call `window.location.reload()` to force a browser reload. The application context will automatically show the login page if the token is missing or invalid, so the user will be shown this page and can log back in. Typically the token is set to expire in an hour, so this will force the user to log back in every hour. Currently the session will still expire, but the UI is just rendered unresponsive with no error messages until the user reloads the browser.

Note that this is not a perfect solution by any means. We rely on the polling to check the user info is still available and valid, however if a user tries to perform an action in between refreshes and the session is timed out, GraphQL responses may contain an error, but these have to be handled differently because the call always returns 200 OK. 

In addition the webshop UI does not appear to do user polling, so another solution is required.

## Context

<!-- Leave a link to the Jira ticket for posterity. -->

[PV-460](https://helsinkisolutionoffice.atlassian.net/browse/PV-460)

## How Has This Been Tested?

Manually tested to see behaviour on session timeout. Note that this can be tricky to test, as it can take ~1 hour for the session to expire.

## Manual Testing Instructions for Reviewers

Sign in as an admin. After approx ~1 hour, if you do not re-authenticate in that time, the browser will automatically reload and you should see the Login screen.



[PV-460]: https://helsinkisolutionoffice.atlassian.net/browse/PV-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ