### PR TITLE
Change default status to “All” in Permits search

### DIFF
--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -14,7 +14,6 @@ import { useOrderByParam, usePageParam } from '../hooks/searchParam';
 import {
   LimitedPermitsQueryData,
   OrderBy,
-  ParkingPermitStatus,
   ParkingPermitStatusOrAll,
   Permit,
   PermitSearchParams,
@@ -146,9 +145,7 @@ const Permits = (): React.ReactElement => {
   const { orderByParam: orderBy, setOrderBy } = useOrderByParam();
 
   const permitSearchParams = {
-    status:
-      (statusParam as ParkingPermitStatusOrAll | null) ||
-      ParkingPermitStatus.VALID,
+    status: (statusParam as ParkingPermitStatusOrAll | null) || 'ALL',
     q: qParam || '',
   };
   const [errorMessage, setErrorMessage] = useState('');


### PR DESCRIPTION
## Description

Change the default status to “All” in Permits search.

## Context

[PV-621](https://helsinkisolutionoffice.atlassian.net/browse/PV-621)

## How Has This Been Tested?

Manually using different permit search criteria.

## Manual Testing Instructions for Reviewers

Open Admin UI permits page and observe that the permit state dropdown is set to "All" by default. Search permits with different permit search criteria. 

## Screenshots
![default state](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/65047bfa-d3d4-4578-9178-9eaad34e01f8)




[PV-621]: https://helsinkisolutionoffice.atlassian.net/browse/PV-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ