### PR TITLE
Always enable customer search button

### DIFF
--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -108,9 +108,7 @@ const PersonalInfo = ({
           onChange={e =>
             updateCustomer({ ...person, nationalIdNumber: e.target.value })
           }>
-          <Button
-            onClick={() => onSearchPerson(nationalIdNumber)}
-            disabled={disableCustomerChange}>
+          <Button onClick={() => onSearchPerson(nationalIdNumber)}>
             {t(`${T_PATH}.search`)}
           </Button>
         </TextInput>


### PR DESCRIPTION
## Description

At the moment, it is not possible to search customer details from DVV in existing permit editing phase. Make it possible by always enable customer search button (but not the national id number text input field itself).

## Context

[PV-625](https://helsinkisolutionoffice.atlassian.net/browse/PV-625)

## How Has This Been Tested?

Locally by opening the permit edit form and changing customer name and address values to something else. Then ckicking the "Search"-button and it will restore the customer original values from DVV.

## Manual Testing Instructions for Reviewers

Test by editing the existing customer firstname, lastname andd address values. Click "Search"-button and observe that the original values are restored to the permit form.

## Screenshots
<img width="345" alt="permit-edit-form-enable-customer-search" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/6f56cb02-22d3-4a3f-9e60-d2b29808de1f">




[PV-625]: https://helsinkisolutionoffice.atlassian.net/browse/PV-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ