### PR TITLE
Refreshing the page in admin pages takes the user back to permits

### DIFF
--- a/src/components/SuperAdminLayout.tsx
+++ b/src/components/SuperAdminLayout.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from 'hds-react';
 import React from 'react';
 import { Outlet } from 'react-router';
 import { Navigate } from 'react-router-dom';
@@ -10,6 +11,20 @@ import styles from './SuperAdminLayout.module.scss';
 
 const SuperAdminLayout = (): React.ReactElement => {
   const userRole = useUserRole();
+  // still loading, we don't know user groups yet
+  if (userRole === UserRole.UNKNOWN) {
+    return (
+      <div className={styles.mainLayout}>
+        <Header />
+        <Divider />
+        <div className={styles.contentContainer}>
+          <LoadingSpinner />
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+  // not a super admin, redirect to Permits page
   if (userRole < UserRole.SUPER_ADMIN) {
     return <Navigate to="/permits" />;
   }


### PR DESCRIPTION
## Description

A race condition exists where default user role "0" is returned if the token is not yet available. In this case, the user is not considered a "super admin". Users without this role are redirected to the Permits page,  so even if the user is a super admin, they have already been redirected and the original destination is lost.

## Context

[PV-488](https://helsinkisolutionoffice.atlassian.net/browse/PV-488)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Log in as super admin EXT-asukptTkuusi@hel.fi
2. Navigate to http://localhost:3000/admin/products
3. Reload the browser 
4. You should remain on the Products page (i.e. Ylläpito)
5. Log out and log back in as EXT-asukptTviisi@hel.fi
6. Enter URL http://localhost:3000/admin/products
7. You should be redirected to Permits (Tunnukset) tab

## Screenshots

![Screenshot from 2023-09-13 13-25-37](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/dad0540e-06d0-4f9d-a3ab-b937e9ab123a)



[PV-488]: https://helsinkisolutionoffice.atlassian.net/browse/PV-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ