### PR TITLE
  Admin UI: Footer of the page interferes with the bottom selection

### DIFF
--- a/src/pages/CreateResidentPermit.module.scss
+++ b/src/pages/CreateResidentPermit.module.scss
@@ -27,24 +27,31 @@
     }
   }
   .footer {
-    padding: $spacing-m 0;
+    padding: $spacing-m $spacing-s;
     box-shadow: 0 -5px 5px -5px $color-black-30;
     position: fixed;
-    width: 100%;
-    max-width: $breakpoint-xl;
-    left: calc(100% - #{$breakpoint-xl}) / 2;
+    width: 99%;
+    left: 0;
     bottom: 0;
     background-color: white;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: center;
+    z-index: 20;
+
+    .inner {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      width: $breakpoint-xl;
+    }
 
     .actions {
       display: flex;
       flex-direction: row;
       .actionButton {
         &:not(:last-child) {
-          margin-right: $spacing-m;
+          margin-right: $spacing-s;
         }
       }
     }
@@ -55,10 +62,11 @@
       background-color: $color-coat-of-arms-light;
       padding: 0 $spacing-s;
       align-items: center;
+      margin-right: $spacing-s;
       .priceLabel {
         font-weight: bold;
         font-size: $fontsize-body-l;
-        margin-right: $spacing-m;
+        margin-right: $spacing-s;
       }
       .totalPrice {
         .totalPriceValue {

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -284,28 +284,30 @@ const CreateResidentPermit = (): React.ReactElement => {
         />
       </div>
       <div className={styles.footer}>
-        <div className={styles.actions}>
-          <Button
-            disabled={
-              customer.activePermits && customer.activePermits.length >= 2
-            }
-            className={styles.actionButton}
-            iconLeft={<IconCheckCircleFill />}
-            onClick={() => setIsConfirmDialogOpen(true)}>
-            {t(`${T_PATH}.save`)}
-          </Button>
-          <Button
-            className={styles.actionButton}
-            variant="secondary"
-            onClick={() => navigate('/permits')}>
-            {t(`${T_PATH}.cancelAndCloseWithoutSaving`)}
-          </Button>
-        </div>
-        <div className={styles.priceInfo}>
-          <div className={styles.priceLabel}>{t(`${T_PATH}.totalPrice`)}</div>
-          <div className={styles.totalPrice}>
-            <span className={styles.totalPriceValue}>{totalPrice}</span>
-            <span className={styles.totalPriceCurrency}>€</span>
+        <div className={styles.inner}>
+          <div className={styles.actions}>
+            <Button
+              disabled={
+                customer.activePermits && customer.activePermits.length >= 2
+              }
+              className={styles.actionButton}
+              iconLeft={<IconCheckCircleFill />}
+              onClick={() => setIsConfirmDialogOpen(true)}>
+              {t(`${T_PATH}.save`)}
+            </Button>
+            <Button
+              className={styles.actionButton}
+              variant="secondary"
+              onClick={() => navigate('/permits')}>
+              {t(`${T_PATH}.cancelAndCloseWithoutSaving`)}
+            </Button>
+          </div>
+          <div className={styles.priceInfo}>
+            <div className={styles.priceLabel}>{t(`${T_PATH}.totalPrice`)}</div>
+            <div className={styles.totalPrice}>
+              <span className={styles.totalPriceValue}>{totalPrice}</span>
+              <span className={styles.totalPriceCurrency}>€</span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Issue was caused by the z-index not being set on a fixed element. In addition some minor padding fixes were added so the buttons are not immediately adjacent to the edge of the footer block and the footer bar expands to the width of the page.

## Context

[PV-623](https://helsinkisolutionoffice.atlassian.net/browse/PV-623)

## How Has This Been Tested?

Tested manually (visual fix)

## Manual Testing Instructions for Reviewers

Navigate to Permits form, scroll up and down the page.

## Screenshots

![Screenshot from 2023-09-15 09-38-12](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/8f7300c1-b36b-4fb5-b503-deb041d9bbfd)



[PV-623]: https://helsinkisolutionoffice.atlassian.net/browse/PV-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ