### PR TITLE
Ensure better precision in formatting prices

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,8 +65,8 @@ export function isPermitAddress(
   customerAddress: Address | undefined
 ): boolean {
   return (
-    customerAddress &&
-    address &&
+    !!customerAddress &&
+    !!address &&
     customerAddress.streetName === address.streetName &&
     customerAddress.streetNumber.substring(0, 2) ===
       address.streetNumber.substring(0, 2)
@@ -152,7 +152,8 @@ export function formatVehicleName(vehicle: Vehicle): string {
 }
 
 export function formatPrice(price: number): string {
-  return parseFloat(price.toString()).toFixed(2);
+  // ensure accurate rounding e.g. 90.955 -> 90.96
+  return (Math.round(price * 100) / 100).toFixed(2);
 }
 
 export function formatMonthlyPrice(price: number): string {


### PR DESCRIPTION
## Description

This fix should ensure decimal values are rounded correctly e.g. 90.955 -> 90.96 and not 90.95.

## Context

[PV-622](https://helsinkisolutionoffice.atlassian.net/browse/PV-622)

## How Has This Been Tested?

Tested manually in console (the exact edge case is difficult to replicate in development)




[PV-622]: https://helsinkisolutionoffice.atlassian.net/browse/PV-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ