### PR TITLE
Fix IBAN checking logic from permit edit preview

### DIFF
--- a/src/components/permitDetail/PermitPriceChangeInfo.tsx
+++ b/src/components/permitDetail/PermitPriceChangeInfo.tsx
@@ -1,7 +1,7 @@
 import { RadioButton, TextInput } from 'hds-react';
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { PermitPriceChange } from '../../types';
+import { PermitPriceChange, RefundAccountOption } from '../../types';
 import {
   formatDateDisplay,
   formatMonthlyPrice,
@@ -68,16 +68,13 @@ const PriceChangeItem = ({
   );
 };
 
-enum RefundAccountOption {
-  KNOWN = 'known',
-  UNKNOWN = 'unknown',
-}
-
 export interface PermitPriceChangeInfoProps {
   className?: string;
   priceChangeList: PermitPriceChange[];
   refundAccountNumber: string;
+  refundAccountOption: string;
   onChangeRefundAccountNumber: (account: string) => void;
+  onChangeRefundAccountOption: (option: string) => void;
 }
 
 const getPriceChangeType = (priceChangeTotal: number): PriceChangeType => {
@@ -96,12 +93,12 @@ const PermitPriceChangeInfo = ({
   className,
   priceChangeList,
   refundAccountNumber,
+  refundAccountOption,
   onChangeRefundAccountNumber,
+  onChangeRefundAccountOption,
 }: PermitPriceChangeInfoProps): React.ReactElement => {
   const { t } = useTranslation();
-  const [refundAccountOption, setRefundAccountOption] = useState(
-    RefundAccountOption.KNOWN
-  );
+
   const newOrderTotal = priceChangeList.reduce(
     (total, item) => total + item.newPrice * item.monthCount,
     0
@@ -195,7 +192,9 @@ const PermitPriceChangeInfo = ({
                 value={RefundAccountOption.KNOWN}
                 checked={refundAccountOption === RefundAccountOption.KNOWN}
                 onChange={e =>
-                  setRefundAccountOption(e.target.value as RefundAccountOption)
+                  onChangeRefundAccountOption(
+                    e.target.value as RefundAccountOption
+                  )
                 }
               />
               <TextInput
@@ -207,6 +206,7 @@ const PermitPriceChangeInfo = ({
                 value={refundAccountNumber}
                 onChange={e => onChangeRefundAccountNumber(e.target.value)}
                 errorText={
+                  refundAccountOption === RefundAccountOption.UNKNOWN ||
                   isValidIBAN(refundAccountNumber)
                     ? undefined
                     : t('errors.invalidIBAN')
@@ -219,7 +219,9 @@ const PermitPriceChangeInfo = ({
                 value={RefundAccountOption.UNKNOWN}
                 checked={refundAccountOption === RefundAccountOption.UNKNOWN}
                 onChange={e => {
-                  setRefundAccountOption(e.target.value as RefundAccountOption);
+                  onChangeRefundAccountOption(
+                    e.target.value as RefundAccountOption
+                  );
                   onChangeRefundAccountNumber('');
                 }}
               />

--- a/src/components/residentPermit/EditResidentPermitPreview.tsx
+++ b/src/components/residentPermit/EditResidentPermitPreview.tsx
@@ -1,7 +1,11 @@
 import { Button, IconCheckCircleFill } from 'hds-react';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PermitDetail, PermitPriceChange } from '../../types';
+import {
+  PermitDetail,
+  PermitPriceChange,
+  RefundAccountOption,
+} from '../../types';
 import { isValidIBAN } from '../../utils';
 import CustomerInfo from '../permitDetail/CustomerInfo';
 import PermitInfo from '../permitDetail/PermitInfo';
@@ -31,6 +35,9 @@ const EditResidentPermitPreview = ({
   onConfirm,
 }: EditResidentPermitPreviewProps): React.ReactElement => {
   const { t } = useTranslation();
+  const [refundAccountOption, setRefundAccountOption] = useState(
+    RefundAccountOption.KNOWN
+  );
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
@@ -47,7 +54,9 @@ const EditResidentPermitPreview = ({
             className={styles.permitPriceChange}
             priceChangeList={priceChangeList}
             refundAccountNumber={refundAccountNumber}
+            refundAccountOption={refundAccountOption}
             onChangeRefundAccountNumber={onChangeRefundAccountNumber}
+            onChangeRefundAccountOption={setRefundAccountOption}
           />
         </div>
       </div>
@@ -61,7 +70,10 @@ const EditResidentPermitPreview = ({
           </Button>
           <Button
             disabled={
-              refundAccountNumber !== '' && isValidIBAN(refundAccountNumber)
+              !(
+                refundAccountOption === RefundAccountOption.UNKNOWN ||
+                isValidIBAN(refundAccountNumber)
+              )
             }
             className={styles.actionButton}
             iconLeft={<IconCheckCircleFill />}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export enum SelectedAddress {
   NONE = 'none',
 }
 
+export enum RefundAccountOption {
+  KNOWN = 'known',
+  UNKNOWN = 'unknown',
+}
+
 export interface Customer {
   id: string;
   sourceId: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -366,6 +366,9 @@ export function getPermitTotalPrice(
 }
 
 export function isValidIBAN(value: string): boolean {
+  if (!value || value.trim() === '') {
+    return false;
+  }
   const iban = extractIBAN(value);
   return iban.valid && iban.countryCode === 'FI';
 }


### PR DESCRIPTION
## Description

Fix IBAN checking logic from permit edit preview for the following cases:

1. IBAN empty: show validation error and disable preview Save-button
<img width="464" alt="iban empty - save disabled" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/500d7f9c-8016-4f45-b29f-2906c3c5bd1f">

2. IBAN given, but incorrect: show validation error and disable preview Save-button
<img width="468" alt="iban known but incorrect - save disabled" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/ef86decb-b092-4800-a50f-5c51a9966d5d">

3. IBAN given and correct: enable preview Save-button
<img width="468" alt="iban known and correct - save enabled" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/03e399b6-2f1d-420f-bbec-bc76e3faebf1">

4. IBAN not known option selected: enable preview Save-button
<img width="480" alt="iban unknown - save enabled" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/be347e08-e1a6-44e4-ba3f-55b1ab0e9dbf">

## Context

[PV-634](https://helsinkisolutionoffice.atlassian.net/browse/PV-634)

## How Has This Been Tested?

Manually.


[PV-634]: https://helsinkisolutionoffice.atlassian.net/browse/PV-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ