### PR TITLE
Reset permit fields on person and vehicle search

### DIFF
--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -75,6 +75,8 @@ interface EditResidentPermitFormProps {
   className?: string;
   permit: PermitDetail;
   permitPrices: PermitPrice[];
+  onResetPermit: (nationalIdNumber: string) => void;
+  onResetVehicle: (regNumber: string) => void;
   onUpdatePermit: (permit: PermitDetail) => void;
   onCancel: () => void;
   onConfirm: () => void;
@@ -84,6 +86,8 @@ const EditResidentPermitForm = ({
   className,
   permit,
   permitPrices,
+  onResetPermit,
+  onResetVehicle,
   onUpdatePermit,
   onCancel,
   onConfirm,
@@ -122,6 +126,7 @@ const EditResidentPermitForm = ({
     if (!customer.nationalIdNumber) {
       return;
     }
+    onResetVehicle(regNumber);
     getVehicle({
       variables: { regNumber, nationalIdNumber: customer.nationalIdNumber },
     });
@@ -131,6 +136,7 @@ const EditResidentPermitForm = ({
     onUpdatePermit(newPermit);
 
   const handleSearchPerson = (nationalIdNumber: string) => {
+    onResetPermit(nationalIdNumber);
     getCustomer({
       variables: { query: { nationalIdNumber } },
     }).then(response => {

--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -94,6 +94,15 @@ const PersonalInfo = ({
       },
     });
   };
+
+  // automatically pre-select the primary address if customer
+  // has at least one address and none selected
+  const isPrimaryAddressSelected =
+    selectedAddress === SelectedAddress.PRIMARY ||
+    (selectedAddress === SelectedAddress.NONE &&
+      !addressSecurityBan &&
+      !!primaryAddress);
+
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.personalInfo`)}</div>
@@ -150,7 +159,7 @@ const PersonalInfo = ({
             name="selectedAddress"
             label={t(`${T_PATH}.primaryAddress`)}
             value={addressSecurityBan ? '' : SelectedAddress.PRIMARY}
-            checked={selectedAddress === SelectedAddress.PRIMARY}
+            checked={isPrimaryAddressSelected}
             onChange={() => {
               setSelectedAddress(SelectedAddress.PRIMARY);
               onSelectAddress(

--- a/src/components/residentPermit/VehicleInfo.tsx
+++ b/src/components/residentPermit/VehicleInfo.tsx
@@ -126,7 +126,7 @@ const VehicleInfo = ({
           id="emission"
           className={styles.fieldItem}
           label={t(`${T_PATH}.emission`)}
-          value={emission}
+          value={emission || 0}
           min={0}
           step={1}
           onChange={e =>

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -6,7 +6,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { getEmptyPermit } from '../components/residentPermit/consts';
+import {
+  getEmptyPermit,
+  initialVehicle,
+} from '../components/residentPermit/consts';
 import PermitInfo from '../components/residentPermit/PermitInfo';
 import PersonalInfo from '../components/residentPermit/PersonalInfo';
 import VehicleInfo from '../components/residentPermit/VehicleInfo';
@@ -211,10 +214,15 @@ const CreateResidentPermit = (): React.ReactElement => {
       })
       .catch(error => setErrorMessage(error.message));
   };
+
   const handleSearchVehicle = (regNumber: string) => {
     if (!customer.nationalIdNumber) {
       return;
     }
+    setPermit({
+      ...permit,
+      vehicle: { ...initialVehicle, registrationNumber: regNumber },
+    });
     getVehicle({
       variables: { regNumber, nationalIdNumber: customer.nationalIdNumber },
     });
@@ -227,7 +235,13 @@ const CreateResidentPermit = (): React.ReactElement => {
     setPermit(newPermit);
     updatePermitPrices(newPermit);
   };
+
   const handleSearchPerson = (nationalIdNumber: string) => {
+    const emptyPermit = getEmptyPermit();
+    setPermit({
+      ...emptyPermit,
+      customer: { ...emptyPermit.customer, nationalIdNumber },
+    });
     getCustomer({
       variables: { query: { nationalIdNumber } },
     });

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -7,6 +7,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { makePrivate } from '../auth/utils';
 import Breadcrumbs from '../components/common/Breadcrumbs';
 import ConfirmDialog from '../components/common/ConfirmDialog';
+import {
+  getEmptyPermit,
+  initialVehicle,
+} from '../components/residentPermit/consts';
 import EditResidentPermitForm from '../components/residentPermit/EditResidentPermitForm';
 import EditResidentPermitPreview from '../components/residentPermit/EditResidentPermitPreview';
 import {
@@ -243,6 +247,21 @@ const EditResidentPermit = (): React.ReactElement => {
     return <div>{t(`${T_PATH}.loading`)}</div>;
   }
 
+  const handleResetPermit = (nationalIdNumber: string) => {
+    const emptyPermit = getEmptyPermit();
+    setPermit({
+      ...emptyPermit,
+      customer: { ...emptyPermit.customer, nationalIdNumber },
+    });
+  };
+
+  const handleResetVehicle = (registrationNumber: string) => {
+    setPermit({
+      ...permit,
+      vehicle: { ...initialVehicle, registrationNumber },
+    });
+  };
+
   const handleUpdatePermit = () => {
     updateResidentPermit({
       variables: {
@@ -275,6 +294,8 @@ const EditResidentPermit = (): React.ReactElement => {
         <EditResidentPermitForm
           permit={permit}
           permitPrices={permitPrices}
+          onResetPermit={handleResetPermit}
+          onResetVehicle={handleResetVehicle}
           onUpdatePermit={updatedPermit => {
             setPermit(updatedPermit);
             updatePermitPrices(updatedPermit, !updatedPermit.primaryVehicle);


### PR DESCRIPTION
When a new search is initiated for a person or vehicle, reset fields accordingly.

## Context

[PV-635](https://helsinkisolutionoffice.atlassian.net/browse/PV-635)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Create a new permit:

1. Enter an ID for the person search, click "Hae/Search".
2. Enter a registration number for vehicle search, click "Hae/Search"
3. Search for a new vehicle registration number. Existing vehicle details should be reset/set to default before new vehicle appears.
4. Search for a new person. All permit details should be reset/set to default before new person details appear.  You will then need to search for a vehicle belonging to that person.

Edit an existing permit:

1. Find an existing permit, open Edit form
2. Search for another vehicle, vehicle details should disappear before new vehicle appears.

## Screenshots

![Screenshot from 2023-09-29 15-10-57](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/e8a1372a-69f0-43b8-9eea-ab61789834cc)


[PV-635]: https://helsinkisolutionoffice.atlassian.net/browse/PV-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ