### PR TITLE
Ensure other address is only selected if available

### DIFF
--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -2,7 +2,13 @@ import { gql, useLazyQuery } from '@apollo/client';
 import { Button, IconCheckCircleFill } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Customer, PermitDetail, PermitPrice, Vehicle } from '../../types';
+import {
+  Address,
+  Customer,
+  PermitDetail,
+  PermitPrice,
+  Vehicle,
+} from '../../types';
 import styles from './EditResidentPermitForm.module.scss';
 import PermitInfo from './PermitInfo';
 import PersonalInfo from './PersonalInfo';
@@ -155,6 +161,46 @@ const EditResidentPermitForm = ({
       vehicle: newVehicle,
     });
   };
+  // ensure address has all correct fields
+  const handleSelectAddress = (
+    address: Address | undefined,
+    apartment: string | undefined
+  ) => {
+    if (!!address && address.id && address.zone) {
+      const { address: currentAddress, addressApartment: currentApartment } =
+        permit;
+      if (currentAddress?.id === address.id) {
+        onUpdatePermit({
+          ...permit,
+          address,
+          addressApartment: currentApartment ?? apartment ?? '',
+          parkingZone: address.zone,
+        });
+      }
+    }
+  };
+
+  const updateAddress = () => {
+    const { address: currentAddress } = permit;
+    onUpdatePermit({
+      ...permit,
+      address: currentAddress ?? permit?.customer?.primaryAddress,
+    });
+    handleSelectAddress(
+      permit?.customer?.otherAddress,
+      permit?.customer?.otherAddressApartment
+    );
+    handleSelectAddress(
+      permit?.customer?.primaryAddress,
+      permit?.customer?.primaryAddressApartment
+    );
+  };
+
+  const handleConfirm = () => {
+    updateAddress();
+    onConfirm();
+  };
+
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.title`)}</div>
@@ -200,7 +246,7 @@ const EditResidentPermitForm = ({
           <Button
             className={styles.actionButton}
             iconLeft={<IconCheckCircleFill />}
-            onClick={() => onConfirm()}>
+            onClick={handleConfirm}>
             {t(`${T_PATH}.continue`)}
           </Button>
         </div>

--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -95,13 +95,15 @@ const PersonalInfo = ({
     });
   };
 
-  // automatically pre-select the primary address if customer
-  // has at least one address and none selected
-  const isPrimaryAddressSelected =
-    selectedAddress === SelectedAddress.PRIMARY ||
-    (selectedAddress === SelectedAddress.NONE &&
-      !addressSecurityBan &&
-      !!primaryAddress);
+  let isPrimaryAddressSelected = false;
+  let isOtherAddressSelected = false;
+
+  if (!addressSecurityBan) {
+    isOtherAddressSelected =
+      !!otherAddress && selectedAddress === SelectedAddress.OTHER;
+
+    isPrimaryAddressSelected = !isOtherAddressSelected && !!primaryAddress;
+  }
 
   return (
     <div className={className}>
@@ -182,7 +184,7 @@ const PersonalInfo = ({
             name="selectedAddress"
             label={t(`${T_PATH}.otherAddress`)}
             value={addressSecurityBan ? '' : SelectedAddress.OTHER}
-            checked={selectedAddress === SelectedAddress.OTHER}
+            checked={isOtherAddressSelected}
             onChange={() => {
               setSelectedAddress(SelectedAddress.OTHER);
               onSelectAddress(SelectedAddress.OTHER, otherAddress as Address);


### PR DESCRIPTION
The primary address will also be selected only if the other address is not selected.

In addition, neither address should be selectable if there is no primary or other address available (e.g. with new permit or missing address info).

Refs: PV-638

## Context

[PV-638](https://helsinkisolutionoffice.atlassian.net/browse/PV-638)

## How Has This Been Tested?

Tested manually:

1. New permit, changing the user ID number
2. Editing an existing permit, selecting either address or looking up a new address

[PV-638]: https://helsinkisolutionoffice.atlassian.net/browse/PV-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ