### PR TITLE
Add Traficom copyrights for vehicle fields

### DIFF
--- a/src/components/permitDetail/VehicleInfo.module.scss
+++ b/src/components/permitDetail/VehicleInfo.module.scss
@@ -31,6 +31,10 @@
     display: flex;
     flex-direction: column;
   }
+  .vehicleCopyright {
+    margin-top: $spacing-xs;
+    font-size: $fontsize-body-s;
+  }
 }
 
 .invalidVehicle {

--- a/src/components/permitDetail/VehicleInfo.tsx
+++ b/src/components/permitDetail/VehicleInfo.tsx
@@ -61,6 +61,9 @@ const VehicleInfo = ({
           label={t(`${T_PATH}.consentLowEmissionDiscountText`)}
           checked={consentLowEmissionAccepted}
         />
+        <div className={styles.vehicleCopyright}>
+          © {t(`${T_PATH}.vehicleCopyright`)}
+        </div>
       </div>
 
       {!activeTemporaryVehicle &&

--- a/src/components/residentPermit/VehicleInfo.module.scss
+++ b/src/components/residentPermit/VehicleInfo.module.scss
@@ -27,3 +27,8 @@
     }
   }
 }
+
+.vehicleCopyright {
+  margin-top: $spacing-xs;
+  font-size: $fontsize-body-s;
+}

--- a/src/components/residentPermit/VehicleInfo.tsx
+++ b/src/components/residentPermit/VehicleInfo.tsx
@@ -150,6 +150,9 @@ const VehicleInfo = ({
             })
           }
         />
+        <div className={styles.vehicleCopyright}>
+          © {t(`${T_PATH}.vehicleCopyright`)}
+        </div>
         {permitPrices.length > 0 && (
           <div className={styles.priceInfo}>
             <div className={styles.priceTitle}>{t(`${T_PATH}.price`)}</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -178,7 +178,8 @@
         "invalid": "Not valid",
         "lowEmissionVehicle": "Low emission vehicle",
         "removeTemporaryVehicle": "Remove temporary vehicle",
-        "title": "Vehicle information"
+        "title": "Vehicle information",
+        "vehicleCopyright": "Vehicle information - Transport register, Traficom"
       }
     },
     "permits": {
@@ -288,7 +289,8 @@
         "search": "Search",
         "serialNumber": "Serial number",
         "vehicleClass": "Vehicle class",
-        "vehicleInfo": "Vehicle information"
+        "vehicleInfo": "Vehicle information",
+        "vehicleCopyright": "Vehicle information - Transport register, Traficom"
       }
     },
     "superAdmin": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -219,7 +219,8 @@
         "invalid": "Ei voimassa",
         "lowEmissionVehicle": "Vähäpäästöinen ajoneuvo",
         "removeTemporaryVehicle": "Poista tilapäinen ajoneuvo",
-        "title": "Ajoneuvon tiedot"
+        "title": "Ajoneuvon tiedot",
+        "vehicleCopyright": "Ajoneuvon tiedot - Liikenneasioidenrekisteri, Traficom"
       }
     },
     "permits": {
@@ -331,7 +332,8 @@
         "search": "Hae",
         "serialNumber": "Valmistenumero",
         "vehicleClass": "Ajoneuvoluokka",
-        "vehicleInfo": "Ajoneuvon tiedot"
+        "vehicleInfo": "Ajoneuvon tiedot",
+        "vehicleCopyright": "Ajoneuvon tiedot - Liikenneasioidenrekisteri, Traficom"
       }
     },
     "superAdmin": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -148,7 +148,8 @@
         "invalid": "Inte giltig",
         "lowEmissionVehicle": "Fordon med låga utsläpp",
         "removeTemporaryVehicle": "Ta bort det tillfälliga fordonet",
-        "title": "Fordonsinformation"
+        "title": "Fordonsinformation",
+        "vehicleCopyright": "Fordonsuppgifter - Trafik- och transportregistret, Traficom"
       }
     },
     "permits": {
@@ -258,7 +259,8 @@
         "search": "Sök",
         "serialNumber": "Serienummer",
         "vehicleClass": "Fordonsklass",
-        "vehicleInfo": "Fordonsinformation"
+        "vehicleInfo": "Fordonsinformation",
+        "vehicleCopyright": "Fordonsuppgifter - Trafik- och transportregistret, Traficom"
       }
     },
     "superAdmin": {


### PR DESCRIPTION
## Description

Add Traficom copyrights for vehicle fields.
Update fi/sv/en-translations.

## Context

[PV-658](https://helsinkisolutionoffice.atlassian.net/browse/PV-658)

## How Has This Been Tested?

Manually.

## Screenshots

<img width="862" alt="permit form fi" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/0e8115e2-e76c-4a0f-8fc2-85b3aa44d8ed">
<img width="848" alt="permit form sv" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/d43e2bf5-988f-4304-b1fd-8e2dd17bd04e">
<img width="867" alt="permit form en" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/59551880-4784-4f7b-b79a-1221352c56ff">
<img width="362" alt="admin ui vehicle card fi" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/58c4fa13-0425-40ba-9ee4-c9db8b4e99b9">
<img width="359" alt="admin ui vehicle card sv" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/bda5d08f-4245-48cc-a855-e1690280f0d3">
<img width="365" alt="admin ui vehicle card en" src="https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/cff60b51-f8c2-42f0-9e44-874723cb5e3c">




[PV-658]: https://helsinkisolutionoffice.atlassian.net/browse/PV-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ