### PR TITLE
Add rules for editing permit

### DIFF
--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -17,14 +17,8 @@ import TemporaryVehicle from '../components/permitDetail/TemporaryVehicle';
 import VehicleInfo from '../components/permitDetail/VehicleInfo';
 import useExportData from '../export/useExportData';
 import { formatExportUrlPdf } from '../export/utils';
-import {
-  MutationResponse,
-  ParkingPermitStatus,
-  PermitContractType,
-  PermitDetailData,
-  PermitEndType,
-} from '../types';
-import { formatCustomerName } from '../utils';
+import { MutationResponse, PermitDetailData, PermitEndType } from '../types';
+import { formatCustomerName, isPermitEditable } from '../utils';
 import styles from './PermitDetail.module.scss';
 
 const T_PATH = 'pages.permitDetail';
@@ -217,12 +211,8 @@ const PermitDetail = (): React.ReactElement => {
       currentPeriodEndTime,
       canEndImmediately,
       canEndAfterCurrentPeriod,
-      startTime,
-      contractType,
     } = permitDetail;
-    const isOpenEndedPermitAndStarted =
-      contractType === PermitContractType.OPEN_ENDED &&
-      new Date(startTime) > new Date();
+
     content = (
       <>
         <Breadcrumbs>
@@ -283,10 +273,7 @@ const PermitDetail = (): React.ReactElement => {
                   <Button
                     className={styles.actionButton}
                     iconLeft={<IconPenLine />}
-                    disabled={
-                      status === ParkingPermitStatus.CLOSED ||
-                      !!isOpenEndedPermitAndStarted
-                    }
+                    disabled={!isPermitEditable(permitDetail)}
                     onClick={() => navigate('edit')}>
                     {t(`${T_PATH}.edit`)}
                   </Button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,8 @@ export interface Permit {
   startTime: string;
   primaryVehicle: boolean;
   endTime?: string;
+  currentPeriodEndTime?: string;
+  contractType: PermitContractType;
   monthCount: number;
 }
 


### PR DESCRIPTION
Permit should be editable if:

1) Not Closed
2) Is Fixed-Period
3) Is Open-Ended and current period ends > 3 days from now

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-724](https://helsinkisolutionoffice.atlassian.net/browse/PV-724)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Find a valid open-ended permit and adjust start time, so the permit start time + 1 month is less than 3 days from now. The "Muokkaa" button should be **disabled**.
2. Find any Closed (fixed or open ended) permit. The "Muokkaa" button should be **disabled**.
3. Any other permits, the "Muokkaa" button should be **enabled**.

## Screenshots

![Screenshot from 2023-11-28 14-03-46](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/a99b69b3-1f31-4e45-ab65-256d9291c17e)
