### PR TITLE
Disable Traficom-fetched vehicle informations

### DIFF
--- a/src/components/common/EmissionTypeSelect.tsx
+++ b/src/components/common/EmissionTypeSelect.tsx
@@ -11,6 +11,7 @@ interface EmissionTypeSelectProps {
   className?: string;
   label: string;
   value: EmissionType;
+  disabled: boolean;
   onChange: (value: EmissionType) => void;
 }
 
@@ -21,6 +22,7 @@ const EMISSION_TYPE_OPTIONS: EmissionTypeOption[] = Object.values(
 const EmissionTypeSelect = ({
   label,
   value,
+  disabled,
   className,
   onChange,
 }: EmissionTypeSelectProps): React.ReactElement => (
@@ -29,6 +31,7 @@ const EmissionTypeSelect = ({
     label={label}
     options={EMISSION_TYPE_OPTIONS}
     value={{ label: value, value }}
+    disabled={disabled}
     onChange={(option: EmissionTypeOption) => onChange(option.value)}
   />
 );

--- a/src/components/common/EuroClassSelect.tsx
+++ b/src/components/common/EuroClassSelect.tsx
@@ -10,6 +10,7 @@ interface EuroClassSelectProps {
   className?: string;
   label: string;
   value: number;
+  disabled: boolean;
   onChange: (value: number) => void;
 }
 
@@ -43,6 +44,7 @@ const EURO_CLASS_OPTIONS: EuroClassOption[] = [
 const EuroClassSelect = ({
   label,
   value,
+  disabled,
   className,
   onChange,
 }: EuroClassSelectProps): React.ReactElement => (
@@ -51,6 +53,7 @@ const EuroClassSelect = ({
     label={label}
     options={EURO_CLASS_OPTIONS}
     value={{ label: `Euro ${value}`, value }}
+    disabled={disabled}
     onChange={(option: EuroClassOption) => onChange(option.value)}
   />
 );

--- a/src/components/common/PowerTypeSelect.tsx
+++ b/src/components/common/PowerTypeSelect.tsx
@@ -15,6 +15,7 @@ interface PowerTypeSelectProps {
   className?: string;
   label: string;
   powerType: PowerType;
+  disabled: boolean;
   onChange: (powerType: PowerType) => void;
 }
 
@@ -22,6 +23,7 @@ const PowerTypeSelect = ({
   label,
   powerType,
   className,
+  disabled,
   onChange,
 }: PowerTypeSelectProps): React.ReactElement => {
   const { t } = useTranslation();
@@ -57,6 +59,7 @@ const PowerTypeSelect = ({
         name: powerType.name,
         value: powerType.identifier,
       }}
+      disabled={disabled}
       onChange={(option: PowerTypeOption) =>
         onChange({
           name: option.name,

--- a/src/components/common/VehicleClassSelect.tsx
+++ b/src/components/common/VehicleClassSelect.tsx
@@ -11,6 +11,7 @@ interface VehicleClassSelectProps {
   className?: string;
   label: string;
   value: VehicleClass;
+  disabled: boolean;
   onChange: (value: VehicleClass) => void;
 }
 
@@ -22,6 +23,7 @@ const VehicleClassSelect = ({
   label,
   value,
   className,
+  disabled,
   onChange,
 }: VehicleClassSelectProps): React.ReactElement => (
   <Select
@@ -29,6 +31,7 @@ const VehicleClassSelect = ({
     label={label}
     options={VEHICLE_CLASS_OPTIONS}
     value={{ label: value, value }}
+    disabled={disabled}
     onChange={(option: VehicleClassOption) => onChange(option.value)}
   />
 );

--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -84,6 +84,7 @@ interface EditResidentPermitFormProps {
   permitPrices: PermitPrice[];
   onResetPermit: (nationalIdNumber: string) => void;
   onResetVehicle: (regNumber: string) => void;
+  onClearVehicle: () => void;
   onUpdatePermit: (permit: PermitDetail) => void;
   onCancel: () => void;
   onConfirm: () => void;
@@ -95,6 +96,7 @@ const EditResidentPermitForm = ({
   permitPrices,
   onResetPermit,
   onResetVehicle,
+  onClearVehicle,
   onUpdatePermit,
   onCancel,
   onConfirm,
@@ -102,8 +104,12 @@ const EditResidentPermitForm = ({
   const { t } = useTranslation();
   const [personSearchError, setPersonSearchError] = useState('');
   const [vehicleSearchError, setVehicleSearchError] = useState('');
-  const { customer, vehicle, address: permitAddress } = permit;
-
+  const {
+    customer,
+    vehicle,
+    address: permitAddress,
+    disableVehicleFields,
+  } = permit;
   const [getCustomer] = useLazyQuery<{
     customer: Customer;
   }>(CUSTOMER_QUERY, {
@@ -124,6 +130,7 @@ const EditResidentPermitForm = ({
       onUpdatePermit({
         ...permit,
         vehicle: data.vehicle,
+        disableVehicleFields: true,
       });
     },
     onError: error => setVehicleSearchError(error.message),
@@ -137,6 +144,11 @@ const EditResidentPermitForm = ({
     getVehicle({
       variables: { regNumber, nationalIdNumber: customer.nationalIdNumber },
     });
+  };
+
+  const handleClearVehicle = () => {
+    setVehicleSearchError('');
+    onClearVehicle();
   };
 
   const handleUpdatePermit = (newPermit: PermitDetail) =>
@@ -224,10 +236,12 @@ const EditResidentPermitForm = ({
         <VehicleInfo
           className={styles.column}
           vehicle={vehicle}
+          disableVehicleFields={disableVehicleFields}
           permitPrices={permitPrices}
           searchError={vehicleSearchError}
           onSearchRegistrationNumber={handleSearchVehicle}
           onUpdateVehicle={handleUpdateVehicle}
+          onClearVehicle={handleClearVehicle}
         />
         <PermitInfo
           className={styles.column}

--- a/src/components/residentPermit/VehicleInfo.tsx
+++ b/src/components/residentPermit/VehicleInfo.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Checkbox,
+  IconTrash,
   Notification,
   NumberInput,
   TextInput,
@@ -40,8 +41,10 @@ interface VehicleInfoProps {
   vehicle: Vehicle;
   searchError?: string;
   permitPrices: PermitPrice[];
+  disableVehicleFields: boolean;
   onSearchRegistrationNumber: (regNumber: string) => void;
   onUpdateVehicle: (vehicle: Vehicle) => void;
+  onClearVehicle: () => void;
 }
 
 const VehicleInfo = ({
@@ -49,8 +52,10 @@ const VehicleInfo = ({
   vehicle,
   searchError,
   permitPrices,
+  disableVehicleFields,
   onSearchRegistrationNumber,
   onUpdateVehicle,
+  onClearVehicle,
 }: VehicleInfoProps): React.ReactElement => {
   const { t } = useTranslation();
   const {
@@ -95,6 +100,13 @@ const VehicleInfo = ({
             {t(`${T_PATH}.search`)}
           </Button>
         </TextInput>
+        <Button
+          variant="supplementary"
+          onClick={onClearVehicle}
+          size="small"
+          iconLeft={<IconTrash size="s" />}>
+          {t(`${T_PATH}.clear`)}
+        </Button>
         {availableRestrictions.map(restriction => (
           <Notification type="info" key={restriction}>
             <div>{t(`${T_PATH}.restrictions.text`, { restriction })}</div>
@@ -107,6 +119,7 @@ const VehicleInfo = ({
           id="manufacturer"
           label={t(`${T_PATH}.manufacturer`)}
           value={manufacturer}
+          disabled={!!disableVehicleFields}
           onChange={e =>
             onUpdateVehicle({ ...vehicle, manufacturer: e.target.value })
           }
@@ -116,12 +129,14 @@ const VehicleInfo = ({
           id="model"
           label={t(`${T_PATH}.model`)}
           value={model}
+          disabled={!!disableVehicleFields}
           onChange={e => onUpdateVehicle({ ...vehicle, model: e.target.value })}
         />
         <VehicleClassSelect
           className={styles.fieldItem}
           label={t(`${T_PATH}.vehicleClass`)}
           value={vehicleClass}
+          disabled={!!disableVehicleFields}
           onChange={value =>
             onUpdateVehicle({ ...vehicle, vehicleClass: value })
           }
@@ -131,6 +146,7 @@ const VehicleInfo = ({
           id="serialNumber"
           label={t(`${T_PATH}.serialNumber`)}
           value={serialNumber}
+          disabled={!!disableVehicleFields}
           onChange={e =>
             onUpdateVehicle({ ...vehicle, serialNumber: e.target.value })
           }
@@ -139,18 +155,21 @@ const VehicleInfo = ({
           className={styles.fieldItem}
           label={t(`${T_PATH}.euroClass`)}
           value={euroClass}
+          disabled={!!disableVehicleFields}
           onChange={value => onUpdateVehicle({ ...vehicle, euroClass: value })}
         />
         <PowerTypeSelect
           className={styles.fieldItem}
           label={t(`${T_PATH}.powerType`)}
           powerType={powerType}
+          disabled={!!disableVehicleFields}
           onChange={pType => onUpdateVehicle({ ...vehicle, powerType: pType })}
         />
         <EmissionTypeSelect
           className={styles.fieldItem}
           label={t(`${T_PATH}.emissionType`)}
           value={emissionType}
+          disabled={!!disableVehicleFields}
           onChange={value =>
             onUpdateVehicle({ ...vehicle, emissionType: value })
           }
@@ -160,6 +179,7 @@ const VehicleInfo = ({
           className={styles.fieldItem}
           label={t(`${T_PATH}.emission`)}
           value={emission || 0}
+          disabled={!!disableVehicleFields}
           min={0}
           step={1}
           onChange={e =>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -291,6 +291,7 @@
         "vehicleClass": "Vehicle class",
         "vehicleInfo": "Vehicle information",
         "vehicleCopyright": "Vehicle information - Transport register, Traficom",
+        "clear": "Clear",
         "restrictions": {
           "text": "Traficom has the following restriction notification for this vehicle: {{restriction}}. You may still continue with the purchase of this parking permit.",
           "driving_ban": "Driving ban",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -334,6 +334,7 @@
         "vehicleClass": "Ajoneuvoluokka",
         "vehicleInfo": "Ajoneuvon tiedot",
         "vehicleCopyright": "Ajoneuvon tiedot - Liikenneasioidenrekisteri, Traficom",
+        "clear": "Tyhjennä",
         "restrictions": {
           "text": "Traficom ilmoittaa ajoneuvolle seuraavan rajoitustiedon: {{restriction}}.",
           "driving_ban": "Ajokielto",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -260,7 +260,8 @@
         "serialNumber": "Serienummer",
         "vehicleClass": "Fordonsklass",
         "vehicleInfo": "Fordonsinformation",
-        "vehicleCopyright": "Fordonsuppgifter - Trafik- och transportregistret, Traficom"
+        "vehicleCopyright": "Fordonsuppgifter - Trafik- och transportregistret, Traficom",
+        "clear": "Rensa"
       }
     },
     "superAdmin": {

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -137,7 +137,7 @@ const CreateResidentPermit = (): React.ReactElement => {
   const [errorMessage, setErrorMessage] = useState('');
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
 
-  const { vehicle, customer } = permit;
+  const { vehicle, customer, disableVehicleFields } = permit;
 
   // graphql queries and mutations
   const [getCustomer] = useLazyQuery<{
@@ -168,9 +168,16 @@ const CreateResidentPermit = (): React.ReactElement => {
       setPermit({
         ...permit,
         vehicle: data.vehicle,
+        disableVehicleFields: true,
       });
     },
-    onError: error => setVehicleSearchError(error.message),
+    onError: error => {
+      setVehicleSearchError(error.message);
+      setPermit({
+        ...permit,
+        disableVehicleFields: false,
+      });
+    },
   });
   const [getPermitPrices] = useLazyQuery<{ permitPrices: PermitPrice[] }>(
     PERMIT_PRICES_QUERY,
@@ -237,6 +244,20 @@ const CreateResidentPermit = (): React.ReactElement => {
     updatePermitPrices(newPermit);
   };
 
+  const handleClearVehicle = () => {
+    setVehicleSearchError('');
+    const newPermit = {
+      ...permit,
+      vehicle: initialVehicle,
+    };
+    setPermit({
+      ...permit,
+      vehicle: initialVehicle,
+      disableVehicleFields: false,
+    });
+    updatePermitPrices(newPermit);
+  };
+
   const handleSearchPerson = (nationalIdNumber: string) => {
     const emptyPermit = getEmptyPermit();
     setPermit({
@@ -285,11 +306,13 @@ const CreateResidentPermit = (): React.ReactElement => {
         />
         <VehicleInfo
           vehicle={vehicle}
+          disableVehicleFields={disableVehicleFields}
           permitPrices={permitPrices}
           className={styles.vehicleInfo}
           searchError={vehicleSearchError}
           onSearchRegistrationNumber={handleSearchVehicle}
           onUpdateVehicle={handleUpdateVehicle}
+          onClearVehicle={handleClearVehicle}
         />
         <PermitInfo
           permit={permit}

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -202,6 +202,7 @@ const EditResidentPermit = (): React.ReactElement => {
       setPermit({
         ...permitDetail,
         customer: newCustomer,
+        disableVehicleFields: true,
       });
       setPermitPrices(permitDetail.permitPrices);
     },
@@ -263,6 +264,14 @@ const EditResidentPermit = (): React.ReactElement => {
     });
   };
 
+  const handleClearVehicle = () => {
+    setPermit({
+      ...permit,
+      vehicle: initialVehicle,
+      disableVehicleFields: false,
+    });
+  };
+
   const handleUpdatePermit = () => {
     updateResidentPermit({
       variables: {
@@ -297,6 +306,7 @@ const EditResidentPermit = (): React.ReactElement => {
           permitPrices={permitPrices}
           onResetPermit={handleResetPermit}
           onResetVehicle={handleResetVehicle}
+          onClearVehicle={handleClearVehicle}
           onUpdatePermit={updatedPermit => {
             setPermit(updatedPermit);
             updatePermitPrices(updatedPermit, !updatedPermit.primaryVehicle);

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,7 @@ export interface PermitDetail {
   monthsLeft: number;
   changeLogs: ChangeLog[];
   permitPrices: PermitPrice[];
+  disableVehicleFields: boolean;
 }
 
 export interface PermitDetailData {


### PR DESCRIPTION
## Description

Disable vehicle informations when it has been fetched from Traficom.
Affects both, create and update resident permit forms.
Add "Clear"-button to clear vehicle section contents and remove disabled status from the components.

## Context

[PV-727](https://helsinkisolutionoffice.atlassian.net/browse/PV-727)

## Screenshots

**Create permit form**

![admin ui create permit form disabled fields](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/8b2121a8-a4fb-4fc5-bf6f-f4cf22ab7cc8)

**Edit permit form**

![admin ui edit permit form disabled fields](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/2784933/707882f6-c4a4-455e-ad13-be7847bec85c)
