### PR TITLE
Remove IBAN and refund status rules for disabling "Save" button on edit

### DIFF
--- a/src/components/residentPermit/EditResidentPermitPreview.tsx
+++ b/src/components/residentPermit/EditResidentPermitPreview.tsx
@@ -6,7 +6,6 @@ import {
   PermitPriceChange,
   RefundAccountOption,
 } from '../../types';
-import { isValidIBAN } from '../../utils';
 import CustomerInfo from '../permitDetail/CustomerInfo';
 import PermitInfo from '../permitDetail/PermitInfo';
 import PermitPriceChangeInfo from '../permitDetail/PermitPriceChangeInfo';
@@ -69,12 +68,6 @@ const EditResidentPermitPreview = ({
             {t(`${T_PATH}.goBack`)}
           </Button>
           <Button
-            disabled={
-              !(
-                refundAccountOption === RefundAccountOption.UNKNOWN ||
-                isValidIBAN(refundAccountNumber)
-              )
-            }
             className={styles.actionButton}
             iconLeft={<IconCheckCircleFill />}
             onClick={() => onConfirm()}>


### PR DESCRIPTION
## Context

[PV-721](https://helsinkisolutionoffice.atlassian.net/browse/PV-721)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Find an existing permit in admin UI. The "Save" button should always be enabled, and saving should always work.

## Screenshots

![e082cddb-cfa1-42d1-b86f-3775529ae2a8](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/5474939b-fb33-4e75-8f81-53e36c04f92a)


[PV-721]: https://helsinkisolutionoffice.atlassian.net/browse/PV-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ