### PR TITLE
Enforce start date for admin UI new permit start date

### DIFF
--- a/src/components/residentPermit/PermitInfo.tsx
+++ b/src/components/residentPermit/PermitInfo.tsx
@@ -19,6 +19,7 @@ interface PermitInfoProps {
   className?: string;
   editMode?: boolean;
   permit: PermitDetail;
+  minStartDate?: Date;
   onUpdatePermit: (permit: PermitDetail) => void;
 }
 
@@ -26,6 +27,7 @@ const PermitInfo = ({
   className,
   editMode = false,
   permit,
+  minStartDate,
   onUpdatePermit,
 }: PermitInfoProps): React.ReactElement => {
   const { t, i18n } = useTranslation();
@@ -38,6 +40,7 @@ const PermitInfo = ({
     FIXED_PERIOD: t('contractType.fixedPeriod'),
     OPEN_ENDED: t('contractType.openEnded'),
   };
+
   return (
     <div className={className}>
       <div className={styles.title}>{t(`${T_PATH}.permitInfo`)}</div>
@@ -84,6 +87,7 @@ const PermitInfo = ({
           className={styles.fieldItem}
           id="startDate"
           initialMonth={new Date()}
+          minDate={minStartDate}
           label={t(`${T_PATH}.startDate`)}
           language={i18n.language as Language}
           value={formatDateDisplay(permit.startTime)}

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -76,6 +76,7 @@ const CUSTOMER_QUERY = gql`
         id
         primaryVehicle
         monthCount
+        startTime
       }
     }
   }
@@ -281,6 +282,13 @@ const CreateResidentPermit = (): React.ReactElement => {
       0
     )
   );
+
+  const { activePermits } = customer;
+  let minStartDate = new Date();
+  if (activePermits && activePermits.length > 0) {
+    const startTime = new Date(activePermits[0].startTime);
+    minStartDate = startTime > minStartDate ? startTime : minStartDate;
+  }
   return (
     <div className={styles.container}>
       <Breadcrumbs>
@@ -318,6 +326,7 @@ const CreateResidentPermit = (): React.ReactElement => {
           permit={permit}
           className={styles.permitInfo}
           onUpdatePermit={handleUpdatePermit}
+          minStartDate={minStartDate}
         />
       </div>
       <div className={styles.footer}>

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -288,7 +288,9 @@ const CreateResidentPermit = (): React.ReactElement => {
   if (activePermits && activePermits.length > 0) {
     const startTime = new Date(activePermits[0].startTime);
     minStartDate = startTime > minStartDate ? startTime : minStartDate;
+    permit.startTime = minStartDate.toISOString();
   }
+
   return (
     <div className={styles.container}>
       <Breadcrumbs>

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface Address {
 
 export type CustomerActivePermit = Pick<
   Permit,
-  'id' | 'primaryVehicle' | 'monthCount'
+  'id' | 'primaryVehicle' | 'monthCount' | 'startTime'
 >;
 
 export enum SelectedAddress {


### PR DESCRIPTION

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-769](https://helsinkisolutionoffice.atlassian.net/browse/PV-769)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Create a permit. Min date should be today.
2. For same customer, create a second permit. Min date should be date of first permit.

Repeat 1 and 2 for start date in future.

## Screenshots

![Screenshot from 2024-01-23 11-54-02](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/b11a4024-1fd3-4f25-bfe6-0cdd857aac0a)


[PV-769]: https://helsinkisolutionoffice.atlassian.net/browse/PV-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ