### PR TITLE
Ensure that either primary or secondary address is selected.

### DIFF
--- a/src/components/residentPermit/PersonalInfo.tsx
+++ b/src/components/residentPermit/PersonalInfo.tsx
@@ -63,10 +63,8 @@ const PersonalInfo = ({
     if (otherAddress && otherAddress?.id === permitAddress?.id) {
       return SelectedAddress.OTHER;
     }
-    if (primaryAddress && primaryAddress?.id === permitAddress?.id) {
-      return SelectedAddress.PRIMARY;
-    }
-    return SelectedAddress.NONE;
+
+    return SelectedAddress.PRIMARY;
   };
 
   const [selectedAddress, setSelectedAddress] = useState<SelectedAddress>(
@@ -77,7 +75,7 @@ const PersonalInfo = ({
     address: Address,
     addressApartment: string | undefined = undefined
   ) => {
-    if (!address || !address.zone) {
+    if (!address?.zone || addressField === SelectedAddress.NONE) {
       return;
     }
     onUpdatePermit({
@@ -99,16 +97,6 @@ const PersonalInfo = ({
       },
     });
   };
-
-  let isPrimaryAddressSelected = false;
-  let isOtherAddressSelected = false;
-
-  if (!addressSecurityBan) {
-    isOtherAddressSelected =
-      !!otherAddress && selectedAddress === SelectedAddress.OTHER;
-
-    isPrimaryAddressSelected = !isOtherAddressSelected && !!primaryAddress;
-  }
 
   return (
     <div className={className}>
@@ -166,7 +154,7 @@ const PersonalInfo = ({
             name="selectedAddress"
             label={t(`${T_PATH}.primaryAddress`)}
             value={addressSecurityBan ? '' : SelectedAddress.PRIMARY}
-            checked={isPrimaryAddressSelected}
+            checked={selectedAddress === SelectedAddress.PRIMARY}
             onChange={() => {
               setSelectedAddress(SelectedAddress.PRIMARY);
               onSelectAddress(
@@ -190,7 +178,7 @@ const PersonalInfo = ({
             name="selectedAddress"
             label={t(`${T_PATH}.otherAddress`)}
             value={addressSecurityBan ? '' : SelectedAddress.OTHER}
-            checked={isOtherAddressSelected}
+            checked={selectedAddress === SelectedAddress.OTHER}
             onChange={() => {
               setSelectedAddress(SelectedAddress.OTHER);
               onSelectAddress(


### PR DESCRIPTION


## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-787](https://helsinkisolutionoffice.atlassian.net/browse/PV-787)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Case 1: Existing customer, no temp address

1. Find a customer with no temporary address (or remove temp address from a customer in Django admin).
2. Look up customer+permit in admin UI.
3. In the "Hae osoite..." field, look up another address (can be any zone).
4. Once selected, click "Jatka". Permit address should match primary customer address.
5. Click "Tallenna". Permit should be updated with correct address.

Case 2: Existing customer, no primary address
Repeat steps 1-5, but with a customer with no primary address, but just a temp address. 

**Note:** the existing permit should have same address as the temp address, if you are editing in Django admin.

Regression testing:

Customer with both addresses: 

1. Switch permit from primary to temp address and vice-versa, save permit.
2. Change primary address only, select primary address
3. Change temp address only, select temp address

New customer:

1. Create new customer with just primary address from DVV.
2. Create new customer with just temp address from DVV.


## Screenshots

![Screenshot from 2024-03-05 13-55-54](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/e81503b0-68fa-4bde-889e-cb5bfa565487)


[PV-787]: https://helsinkisolutionoffice.atlassian.net/browse/PV-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ