### PR TITLE
Handle address fields from customer query-

### DIFF
--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -22,16 +22,19 @@ const CUSTOMER_QUERY = gql`
       firstName
       lastName
       nationalIdNumber
+      addressSecurityBan
       email
       phoneNumber
       zone
       driverLicenseChecked
       primaryAddress {
+        id
         city
         citySv
         streetName
         streetNumber
         postalCode
+        location
         zone {
           name
           label
@@ -40,11 +43,13 @@ const CUSTOMER_QUERY = gql`
       }
       primaryAddressApartment
       otherAddress {
+        id
         city
         citySv
         streetName
         streetNumber
         postalCode
+        location
         zone {
           name
           label

--- a/src/components/residentPermit/EditResidentPermitForm.tsx
+++ b/src/components/residentPermit/EditResidentPermitForm.tsx
@@ -160,15 +160,56 @@ const EditResidentPermitForm = ({
     onUpdatePermit(newPermit);
 
   const handleSearchPerson = (nationalIdNumber: string) => {
+    const { address: originalAddress } = permit;
+
     onResetPermit(nationalIdNumber);
     getCustomer({
       variables: { query: { nationalIdNumber } },
     }).then(response => {
       if (response.data?.customer) {
-        handleUpdatePermit({
+        const {
+          primaryAddress,
+          primaryAddressApartment,
+          otherAddress,
+          otherAddressApartment,
+        } = response.data?.customer;
+
+        let address = null;
+        let addressApartment = '';
+
+        if (
+          !!otherAddress &&
+          !!originalAddress &&
+          otherAddress.id === originalAddress.id
+        ) {
+          address = otherAddress;
+          addressApartment = otherAddressApartment ?? '';
+        } else {
+          address = primaryAddress;
+          addressApartment = primaryAddressApartment ?? '';
+        }
+
+        let fields = {
           ...permit,
           customer: response.data?.customer,
-        });
+        };
+
+        if (address) {
+          const parkingZone = address.zone ?? {
+            name: '',
+            label: '',
+            labelSv: '',
+          };
+
+          fields = {
+            ...fields,
+            address,
+            addressApartment,
+            parkingZone,
+          };
+        }
+
+        handleUpdatePermit(fields);
       }
     });
   };


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-803](https://helsinkisolutionoffice.atlassian.net/browse/PV-803)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Look up existing permit in admin UI e.g. 290200A905H.
2. Click "Hae" next to Hetu
3. Primary and/or other address should be updated automatically
4. Click "Jatka"
5. Permit address should be updated to match primary or other address
6. Click "Tallenna"
7. Permit should be saved correctly to database and all permit and customer address fields updated.

Regression testing:
* Change primary/other address using "Hae Osoite..." instead of updating from DVV.
* Change between primary and other address.


## Screenshots

![Screenshot from 2024-03-06 09-12-52](https://github.com/City-of-Helsinki/parking-permits-admin-ui/assets/131681805/fca6ff6e-85cf-4566-82fd-6bf551410ff1)



[PV-803]: https://helsinkisolutionoffice.atlassian.net/browse/PV-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ