### PR TITLE
Change minimum date on Temporary permit end date

### DIFF
--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -1,4 +1,4 @@
-import { addDays, addWeeks, format } from 'date-fns';
+import { addWeeks, format } from 'date-fns';
 import { Field, FieldProps, Formik } from 'formik';
 import {
   Button,
@@ -144,8 +144,7 @@ const TemporaryVehicle = ({
                     <DateInput
                       id="endDate"
                       className="date-input"
-                      minDate={form.getFieldProps('startDate').value
-                      }
+                      minDate={form.getFieldProps('startDate').value}
                       maxDate={addWeeks(
                         form.getFieldProps('startDate').value,
                         2

--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -144,10 +144,8 @@ const TemporaryVehicle = ({
                     <DateInput
                       id="endDate"
                       className="date-input"
-                      minDate={addDays(
-                        form.getFieldProps('startDate').value,
-                        1
-                      )}
+                      minDate={form.getFieldProps('startDate').value
+                      }
                       maxDate={addWeeks(
                         form.getFieldProps('startDate').value,
                         2


### PR DESCRIPTION
Temporary vehicle permit minimum end date can now be same as the start date so one day permits can be issued.

Refs SHPPWS-7

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[jira-id](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->
