### PR TITLE
Update refunds to support multiple orders

### DIFF
--- a/src/components/refunds/RefundsDataTable.tsx
+++ b/src/components/refunds/RefundsDataTable.tsx
@@ -52,14 +52,15 @@ const RefundsDataTable = ({
     {
       name: t(`${T_PATH}.orderNumber`),
       field: 'orderId',
-      selector: ({ order }) => order.id,
+      selector: ({ refundOrders }) =>
+        refundOrders.map(order => order.id).join(', '),
       sortable: true,
     },
     {
       name: t(`${T_PATH}.registrationNumber`),
       field: 'registrationNumber',
-      selector: ({ order }) =>
-        order.orderPermits
+      selector: ({ refundPermits }) =>
+        refundPermits
           .map(permit => permit.vehicle.registrationNumber)
           .join(', '),
       sortable: true,

--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -32,13 +32,14 @@ const REFUND_DETAIL_QUERY = gql`
       createdBy
       modifiedAt
       modifiedBy
-      order {
+      refundPermits {
         id
-        orderPermits {
-          vehicle {
-            registrationNumber
-          }
+        vehicle {
+          registrationNumber
         }
+      }
+      refundOrders {
+        id
       }
     }
   }

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -52,13 +52,14 @@ const REFUNDS_QUERY = gql`
         modifiedBy
         acceptedAt
         acceptedBy
-        order {
+        refundPermits {
           id
-          orderPermits {
-            vehicle {
-              registrationNumber
-            }
+          vehicle {
+            registrationNumber
           }
+        }
+        refundOrders {
+          id
         }
       }
       pageInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -488,7 +488,8 @@ export interface Refund {
   modifiedBy: string;
   acceptedAt: string;
   acceptedBy: string;
-  order: Order;
+  refundPermits: [Permit];
+  refundOrders: [Order];
 }
 export interface PagedRefunds {
   objects: Refund[];


### PR DESCRIPTION
## Description

Update refunds to support multiple orders.

Related PR:s: https://github.com/City-of-Helsinki/parking-permits/pull/538
These have to be merged at the same time!

## Context

[PV-877](https://helsinkisolutionoffice.atlassian.net/browse/PV-877)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Test that Refund-functions works normally.

## Screenshots

<img width="1203" alt="admin ui refunds datatable" src="https://github.com/user-attachments/assets/80edd773-c11a-4317-ba35-2830c1c58ed6">



[PV-877]: https://helsinkisolutionoffice.atlassian.net/browse/PV-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ