### PR TITLE
Fix issues with renewal 

### DIFF
--- a/public/silent_renew.html
+++ b/public/silent_renew.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Silent renewal</title>
+  </head>
+  <body>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/oidc-client-ts/2.2.2/browser/oidc-client-ts.min.js"
+      integrity="sha512-pt8b5O4w5Y9/xZpIhPN8Soo/YbC95SxHn0P/Mu39iYB2Ih/09TMS3Id5XPqve2f8DPC6voXOzgQNojCuqO6A4w=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"></script>
+    <script>
+      var mgr = new oidc.UserManager({});
+      mgr.signinSilentCallback().catch(error => {
+        console.error('silent_renew.html error', error);
+      });
+    </script>
+  </body>
+</html>

--- a/src/api/ApiAccessTokenProvider.tsx
+++ b/src/api/ApiAccessTokenProvider.tsx
@@ -1,5 +1,5 @@
-import { getApiTokensFromStorage, LoadingSpinner } from 'hds-react';
-import React, { FC, useEffect } from 'react';
+import { LoadingSpinner } from 'hds-react';
+import React, { FC } from 'react';
 import { useIsAuthorizationReady } from '../auth/useIsAuthReady';
 
 export const ApiAccessTokenContext = React.createContext<null>(null);
@@ -10,12 +10,6 @@ interface Props {
 
 export const ApiAccessTokenProvider: FC<Props> = ({ children }) => {
   const [isReady, loading] = useIsAuthorizationReady();
-
-  useEffect(() => {
-    // Make sure api tokens are available
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const tokens = getApiTokensFromStorage();
-  }, [isReady, loading]);
 
   if (!isReady && loading) {
     return <LoadingSpinner />;

--- a/src/api/ApiAccessTokenProvider.tsx
+++ b/src/api/ApiAccessTokenProvider.tsx
@@ -9,9 +9,9 @@ interface Props {
 }
 
 export const ApiAccessTokenProvider: FC<Props> = ({ children }) => {
-  const [isReady, loading] = useIsAuthorizationReady();
+  const [isReady, loading, , gotTokensOnce] = useIsAuthorizationReady();
 
-  if (!isReady && loading) {
+  if (!isReady && loading && !gotTokensOnce) {
     return <LoadingSpinner />;
   }
 

--- a/src/auth/HandleCallback.tsx
+++ b/src/auth/HandleCallback.tsx
@@ -2,9 +2,7 @@ import * as Sentry from '@sentry/react';
 import {
   LoginCallbackHandler,
   OidcClientError,
-  useApiTokensClient,
   useOidcClient,
-  User,
 } from 'hds-react';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -16,14 +14,11 @@ const HandleCallback = (
   const location = useLocation();
   const navigate = useNavigate();
   const { isAuthenticated } = useOidcClient();
-  const { fetch } = useApiTokensClient();
   const { children } = props;
   const isCallback = isCallbackUrl(location.pathname);
 
-  const onSuccess = (user: User) => {
-    fetch(user);
+  const onSuccess = () => {
     navigate('/permits', { replace: true });
-    window.location.reload();
   };
 
   const onError = (error: OidcClientError | undefined) => {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,5 +1,5 @@
 import { LoginProviderProps } from 'hds-react';
-import { getBooleanEnv, getEnv } from '../utils';
+import { getEnv } from '../utils';
 
 export function getLocationBasedUri(
   property: string | undefined
@@ -22,7 +22,7 @@ const HDSLoginConfig: LoginProviderProps = {
     silent_redirect_uri: getLocationBasedUri(
       getEnv('REACT_APP_OIDC_SILENT_AUTH_PATH')
     ),
-    automaticSilentRenew: getBooleanEnv('REACT_APP_OIDC_AUTO_SILENT_RENEW'),
+    automaticSilentRenew: true,
     response_type: getEnv('REACT_APP_OIDC_RESPONSE_TYPE'),
     post_logout_redirect_uri: getLocationBasedUri(
       getEnv('REACT_APP_OIDC_LOGOUT_PATH')

--- a/src/auth/useIsAuthReady.tsx
+++ b/src/auth/useIsAuthReady.tsx
@@ -3,11 +3,18 @@ import {
   useApiTokensClientTracking,
   useOidcClient,
 } from 'hds-react';
+import { useRef } from 'react';
 
 // eslint-disable-next-line import/prefer-default-export
-export function useIsAuthorizationReady(): [boolean, boolean, boolean] {
+export function useIsAuthorizationReady(): [
+  boolean,
+  boolean,
+  boolean,
+  boolean
+] {
   const { isAuthenticated, isRenewing: isRenewingSession } = useOidcClient();
   const { getTokens, isRenewing: isRenewingApiToken } = useApiTokensClient();
+  const hasFetchedTokensOnce = useRef<boolean>(false);
 
   // The isRenewing* -properties are not updating the hook!
   // All the signals needs to be tracked,
@@ -20,5 +27,9 @@ export function useIsAuthorizationReady(): [boolean, boolean, boolean] {
   const loading = isRenewingSession() || isRenewingApiToken();
   const isReady = isLoggedIn && hasTokens;
 
-  return [isReady, loading, isLoggedIn];
+  if (!hasFetchedTokensOnce.current && hasTokens) {
+    hasFetchedTokensOnce.current = true;
+  }
+
+  return [isReady, loading, isLoggedIn, hasFetchedTokensOnce.current];
 }

--- a/src/auth/useIsAuthReady.tsx
+++ b/src/auth/useIsAuthReady.tsx
@@ -5,7 +5,7 @@ import {
 } from 'hds-react';
 
 // eslint-disable-next-line import/prefer-default-export
-export function useIsAuthorizationReady(): [boolean, boolean] {
+export function useIsAuthorizationReady(): [boolean, boolean, boolean] {
   const { isAuthenticated, isRenewing: isRenewingSession } = useOidcClient();
   const { getTokens, isRenewing: isRenewingApiToken } = useApiTokensClient();
 
@@ -20,5 +20,5 @@ export function useIsAuthorizationReady(): [boolean, boolean] {
   const loading = isRenewingSession() || isRenewingApiToken();
   const isReady = isLoggedIn && hasTokens;
 
-  return [isReady, loading];
+  return [isReady, loading, isLoggedIn];
 }

--- a/src/auth/utils.tsx
+++ b/src/auth/utils.tsx
@@ -1,4 +1,3 @@
-import { useOidcClient } from 'hds-react';
 import React from 'react';
 import { Navigate } from 'react-router';
 import { useIsAuthorizationReady } from './useIsAuthReady';
@@ -8,10 +7,9 @@ export function makePrivate<T>(
   Component: React.ComponentType<T>
 ): React.ComponentType<T> {
   return function PrivateComponent(props: T) {
-    const { isAuthenticated } = useOidcClient();
-    const [isReady, loading] = useIsAuthorizationReady();
+    const [isReady, loading, isAuthenticated] = useIsAuthorizationReady();
 
-    if (!isAuthenticated()) {
+    if (!isAuthenticated) {
       return <Navigate to="/login" />;
     }
     if (!isReady && loading) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,19 +31,17 @@ const container = document.getElementById('root');
 const root = createRoot(container!);
 
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <HDSLoginProvider>
-        <HandleCallback>
-          <ApiAccessTokenProvider>
-            <ApiClientProvider>
-              <App />
-            </ApiClientProvider>
-          </ApiAccessTokenProvider>
-        </HandleCallback>
-      </HDSLoginProvider>
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <HDSLoginProvider>
+      <HandleCallback>
+        <ApiAccessTokenProvider>
+          <ApiClientProvider>
+            <App />
+          </ApiClientProvider>
+        </ApiAccessTokenProvider>
+      </HandleCallback>
+    </HDSLoginProvider>
+  </BrowserRouter>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
## Description

User tokens were frequently expired, but auto renewal was false and `silent_renew.html` was missing. This caused the renewal to get stuck and the loading spinner blocked the UI. It is unknown why the `oidc-client `used in `HDS Login,` still tried sent renewal events.

Fixed by adding the `silent_renewal.html` and changed auto renew to `true`.

Cleaned up some unnecessary code for api token retrieval and renewal checks.

Once the user and api tokens are fetched, the renewal is done under the hood and it is not necessary to indicate it to the user.

There is still one "loading" showing in the content area when api tokens are renewed. Could be removed. The user may fetch exactly at the same time api tokens are renewed, but then the query just fails and can be fetched again. The "loading" text may clear the form unnecessarily.

Removed StrictMode as it seemed to be causing problems detecting api tokens have been fetched. This is probably HDS login issue.

Testing tip:

add the following to the `userManagerSettings` in `src/auth/index.ts`

```
    // eslint-disable-next-line no-magic-numbers
    accessTokenExpiringNotificationTimeInSeconds: 59 * 5,
```

The user renewal starts quite often so, no need to wait for it.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[jira-id](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->
