### PR TITLE
Allow draft permit creation for Admins

### DIFF
--- a/src/auth/utils.tsx
+++ b/src/auth/utils.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router';
 import { useIsAuthorizationReady } from './useIsAuthReady';
+
+const T_PATH = 'components.common.utils';
 
 // eslint-disable-next-line import/prefer-default-export
 export function makePrivate<T>(
   Component: React.ComponentType<T>
 ): React.ComponentType<T> {
   return function PrivateComponent(props: T) {
+    const { t } = useTranslation();
     const [isReady, loading, isAuthenticated] = useIsAuthorizationReady();
 
     if (!isAuthenticated) {
       return <Navigate to="/login" />;
     }
     if (!isReady && loading) {
-      return <div>Loading...</div>;
+      return <div>{t(`${T_PATH}.loading`)}</div>;
     }
     return <Component {...props} />;
   };

--- a/src/components/common/AddressSearch.tsx
+++ b/src/components/common/AddressSearch.tsx
@@ -114,7 +114,7 @@ const AddressSearch = ({
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from 'hds-react';
+import { Button, Dialog, IconArrowUndo, IconCheckCircleFill } from 'hds-react';
 import React from 'react';
 
 interface ConfirmDialogProps {
@@ -41,10 +41,14 @@ const ConfirmDialog = ({
     <Dialog.ActionButtons>
       <Button
         variant={isDeleteConfirmation ? 'danger' : 'primary'}
+        iconLeft={<IconCheckCircleFill />}
         onClick={() => onConfirm()}>
         {confirmLabel}
       </Button>
-      <Button variant="secondary" onClick={() => onCancel()}>
+      <Button
+        variant="secondary"
+        iconLeft={<IconArrowUndo />}
+        onClick={() => onCancel()}>
         {cancelLabel}
       </Button>
     </Dialog.ActionButtons>

--- a/src/components/common/StatusLabel.module.scss
+++ b/src/components/common/StatusLabel.module.scss
@@ -17,6 +17,11 @@
       background-color: $color-draft-fill;
     }
 
+    &.preliminary {
+      border: 1px solid $color-preliminary-border;
+      background-color: $color-preliminary-fill;
+    }
+
     &.paymentInProgress {
       border: 1px solid $color-payment-in-progress-border;
       background-color: $color-payment-in-progress-fill;

--- a/src/components/common/StatusLabel.tsx
+++ b/src/components/common/StatusLabel.tsx
@@ -11,6 +11,7 @@ const StatusLabel = ({ status }: StatusLabeProps): React.ReactElement => {
   const { t } = useTranslation();
   const statusLabelMapping: { [key in ParkingPermitStatus]: string } = {
     [ParkingPermitStatus.DRAFT]: t('permitStatus.draft'),
+    [ParkingPermitStatus.PRELIMINARY]: t('permitStatus.preliminary'),
     [ParkingPermitStatus.PAYMENT_IN_PROGRESS]: t(
       'permitStatus.paymentInProgress'
     ),
@@ -20,6 +21,7 @@ const StatusLabel = ({ status }: StatusLabeProps): React.ReactElement => {
   };
   const statusStyleMapping = {
     [ParkingPermitStatus.DRAFT]: styles.draft,
+    [ParkingPermitStatus.PRELIMINARY]: styles.preliminary,
     [ParkingPermitStatus.PAYMENT_IN_PROGRESS]: styles.paymentInProgress,
     [ParkingPermitStatus.VALID]: styles.valid,
     [ParkingPermitStatus.CANCELLED]: styles.cancelled,

--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -206,7 +206,7 @@ const TemporaryVehicle = ({
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/components/permits/StatusSelect.tsx
+++ b/src/components/permits/StatusSelect.tsx
@@ -15,22 +15,24 @@ interface StatusSelectProps {
   className?: string;
   value: ParkingPermitStatusOrAll;
   onChange: (value: ParkingPermitStatusOrAll) => void;
+  showAllOption?: boolean;
 }
 
 const StatusSelect = ({
   value,
   onChange,
+  showAllOption = true,
   ...otherProps
 }: StatusSelectProps): React.ReactElement => {
   const { t } = useTranslation();
   const statusOptions: StatusOption[] = [
     {
-      label: t(`${T_PATH}.all`),
-      value: 'ALL',
-    },
-    {
       label: <StatusLabel status={ParkingPermitStatus.DRAFT} />,
       value: ParkingPermitStatus.DRAFT,
+    },
+    {
+      label: <StatusLabel status={ParkingPermitStatus.PRELIMINARY} />,
+      value: ParkingPermitStatus.PRELIMINARY,
     },
     {
       label: <StatusLabel status={ParkingPermitStatus.VALID} />,
@@ -49,6 +51,12 @@ const StatusSelect = ({
       value: ParkingPermitStatus.CLOSED,
     },
   ];
+  if (showAllOption) {
+    statusOptions.unshift({
+      label: t(`${T_PATH}.all`),
+      value: 'ALL',
+    });
+  }
   return (
     <Select
       {...otherProps}

--- a/src/components/residentPermit/PermitInfo.tsx
+++ b/src/components/residentPermit/PermitInfo.tsx
@@ -132,6 +132,7 @@ const PermitInfo = ({
         <StatusSelect
           className={styles.fieldItem}
           value={permit.status}
+          showAllOption={false}
           onChange={status =>
             onUpdatePermit({ ...permit, status: status as ParkingPermitStatus })
           }

--- a/src/components/residentPermit/VehicleInfo.tsx
+++ b/src/components/residentPermit/VehicleInfo.tsx
@@ -111,7 +111,9 @@ const VehicleInfo = ({
           </Notification>
         ))}
         {searchError && (
-          <Notification type="error" style={{ whiteSpace: 'pre-wrap' }}>
+          <Notification
+            type="error"
+            style={{ whiteSpace: 'pre-wrap', opacity: 1 }}>
             {searchError}
           </Notification>
         )}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,6 +26,9 @@
           "logout": "Logout"
         }
       },
+      "utils": {
+        "loading": "Ladataan..."
+      },
       "changeLogs": {
         "createdAt": "Created at",
         "createdBy": "Created by",
@@ -65,7 +68,9 @@
           "create_admin_permit_extension_request": "Permit extension created by admin",
           "create_customer_permit_extension_request": "Permit extension created by customer",
           "approve_permit_extension_request": "Permit extension approved",
-          "cancel_permit_extension_request": "Permit extension cancelled"
+          "cancel_permit_extension_request": "Permit extension cancelled",
+          "create_draft_permit": "Draft created",
+          "update_draft_permit": "Draft updated"
         },
         "descriptions": {
           "update_permit": "Permit updated",
@@ -79,7 +84,9 @@
           "create_admin_permit_extension_request": "Permit extension #{{relatedObject.id}} created by admin",
           "create_customer_permit_extension_request": "Permit extension #{{relatedObject.id}} created by customer",
           "approve_permit_extension_request": "Permit extension #{{relatedObject.id}} approved",
-          "cancel_permit_extension_request": "Permit extension #{{relatedObject.id}} cancelled"
+          "cancel_permit_extension_request": "Permit extension #{{relatedObject.id}} cancelled",
+          "create_draft_permit": "Draft created",
+          "update_draft_permit": "Draft updated"
         }
       },
       "dataTable": {
@@ -574,6 +581,7 @@
   "message": {
     "close": "Close",
     "error": "Error",
+    "info": "Info",
     "unauthorized": "You are not authorized to view this page"
   },
   "pages": {
@@ -595,8 +603,10 @@
       "permits": "Permits",
       "residentPermit": "Resident parking permit",
       "save": "Save",
+      "saveAsDraft": "Save as draft",
       "totalPrice": "Total price",
-      "createPermitError": "Permit creation failed"
+      "createPermitError": "Permit creation failed",
+      "draftPermitSaved": "Permit {{permitId}} draft saved"
     },
     "editResidentPermit": {
       "cancelPayment": "Cancel payment",
@@ -615,7 +625,8 @@
       "permitId": "Permit ID",
       "permits": "Permits",
       "residentParkingPermit": "Resident parking permit",
-      "title": "Summary"
+      "title": "Summary",
+      "loading": "Loading..."
     },
     "login": {
       "login": "Login"
@@ -644,7 +655,9 @@
       "save": "Save",
       "downloadPdf": "Download refund details as PDF",
       "title": "Edit refund",
-      "ibanIsRequired": "IBAN number is required"
+      "ibanIsRequired": "IBAN number is required",
+      "loading": "Loading...",
+      "noData": "No data"
     },
     "refunds": {
       "acceptRefunds": "Accept refunds",
@@ -670,7 +683,8 @@
         "confirmTitle": "Confirm delete",
         "confirmMessage": "Address will be permanently deleted. Do you want to proceed?",
         "confirm": "Delete",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "loading": "Loading..."
       },
       "editLowEmissionCriterion": {
         "title": "Edit low emission criterion",
@@ -684,7 +698,8 @@
         "confirmTitle": "Confirm delete",
         "confirmMessage": "Product will be permanently deleted. Do you want to proceed?",
         "confirm": "Delete",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "loading": "Loading..."
       },
       "lowEmissionCriteria": {
         "addNewCriterion": "Add new low emission criterion",
@@ -730,6 +745,7 @@
   },
   "permitStatus": {
     "draft": "Draft",
+    "preliminary": "Preliminary",
     "paymentInProgress": "Payment in progress",
     "valid": "Valid",
     "cancelled": "Cancelled",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -26,6 +26,9 @@
           "logout": "Kirjaudu ulos"
         }
       },
+      "utils": {
+        "loading": "Ladataan..."
+      },
       "changeLogs": {
         "createdAt": "Muutosaika",
         "createdBy": "Muokkaaja",
@@ -65,7 +68,9 @@
           "create_admin_permit_extension_request": "Admin luonut tunnuksen jatkon",
           "create_customer_permit_extension_request": "Asiakas luonut tunnuksen jatkon",
           "approve_permit_extension_request": "Tunnuksen jatko hyväksytty",
-          "cancel_permit_extension_request": "Tunnuksen jatko peruutettu"
+          "cancel_permit_extension_request": "Tunnuksen jatko peruutettu",
+          "create_draft_permit": "Luonnos luotu",
+          "update_draft_permit": "Luonnos päivitetty"
         },
         "descriptions": {
           "update_permit": "Tunnuksen tietoja päivitetty",
@@ -79,7 +84,9 @@
           "create_admin_permit_extension_request": "Admin luonut tunnuksen jatkon #{{relatedObject.id}}",
           "create_customer_permit_extension_request": "Asiakas luonut tunnuksen jatkon #{{relatedObject.id}}",
           "approve_permit_extension_request": "Tunnuksen jatko {{relatedObject.id}} hyväksytty",
-          "cancel_permit_extension_request": "Tunnuksen jatko {{relatedObject.id}} peruutettu"
+          "cancel_permit_extension_request": "Tunnuksen jatko {{relatedObject.id}} peruutettu",
+          "create_draft_permit": "Luonnos luotu",
+          "update_draft_permit": "Luonnos päivitetty"
         }
       },
       "dataTable": {
@@ -574,6 +581,7 @@
   "message": {
     "close": "Sulje",
     "error": "Virhe",
+    "info": "Tieto",
     "unauthorized": "Sinulla ei ole lupaa tarkastella tätä sivua"
   },
   "pages": {
@@ -594,9 +602,11 @@
       "monthCount_other": "{{count}} kuukautta",
       "permits": "Tunnukset",
       "residentPermit": "Asukaspysäköintitunnus",
-      "save": "Tallenna",
+      "save": "Luo tunnus",
+      "saveAsDraft": "Tallenna luonnoksena",
       "totalPrice": "Tunnuksen yhteissumma",
-      "createPermitError": "Tunnuksen luonti epäonnistui"
+      "createPermitError": "Tunnuksen luonti epäonnistui",
+      "draftPermitSaved": "Tunnus {{permitId}} tallennettu luonnoksena"
     },
     "editResidentPermit": {
       "cancelPayment": "Peruuta maksu",
@@ -615,7 +625,8 @@
       "permitId": "Tunnus ID",
       "permits": "Tunnukset",
       "residentParkingPermit": "Asukaspysäköintitunnus",
-      "title": "Yhteenveto"
+      "title": "Yhteenveto",
+      "loading": "Ladataan..."
     },
     "login": {
       "login": "Kirjaudu sisään"
@@ -632,7 +643,8 @@
       "now": "Nyt",
       "permitId": "Tunnus ID",
       "permits": "Tunnukset",
-      "residentParkingPermit": "Asukaspysäköintitunnus"
+      "residentParkingPermit": "Asukaspysäköintitunnus",
+      "loading": "Ladataan..."
     },
     "permits": {
       "createNewPermit": "Luo uusi tunnus",
@@ -645,7 +657,9 @@
       "save": "Tallenna",
       "downloadPdf": "Lataa palautuksen tiedot PDF:nä",
       "title": "Muokkaa Palautusta",
-      "ibanIsRequired": "IBAN-numero vaaditaan"
+      "ibanIsRequired": "IBAN-numero vaaditaan",
+      "loading": "Ladataan...",
+      "noData": "Ei tietoja"
     },
     "refunds": {
       "acceptRefunds": "Hyväksy palautukset",
@@ -671,7 +685,8 @@
         "confirmTitle": "Vahvista poisto",
         "confirmMessage": "Osoite poistetaan pysyvästi. Haluatko jatkaa?",
         "confirm": "Poista",
-        "cancel": "Peruuta"
+        "cancel": "Peruuta",
+        "loading": "Ladataan..."
       },
       "editLowEmissionCriterion": {
         "title": "Muokkaa vähäpäästöisyyskriteeriä",
@@ -685,7 +700,8 @@
         "confirmTitle": "Vahvista poisto",
         "confirmMessage": "Tuote poistetaan pysyvästi. Haluatko jatkaa?",
         "confirm": "Poista",
-        "cancel": "Peruuta"
+        "cancel": "Peruuta",
+        "loading": "Ladataan..."
       },
       "lowEmissionCriteria": {
         "addNewCriterion": "Lisää uusi vähäpäästöisyyskriteeri",
@@ -731,6 +747,7 @@
   },
   "permitStatus": {
     "draft": "Luonnos",
+    "preliminary": "Alustava",
     "paymentInProgress": "Maksussa",
     "valid": "Voimassa",
     "cancelled": "Peruutettu",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -26,6 +26,9 @@
           "logout": "Loggar ut"
         }
       },
+      "utils": {
+        "loading": "Läser in..."
+      },
       "changeLogs": {
         "createdAt": "Gjort",
         "createdBy": "Skapat av",
@@ -65,7 +68,9 @@
           "create_admin_permit_extension_request": "Begäran om förlängning av tillstånd skapad av admin",
           "create_customer_permit_extension_request": "Begäran om förlängning av tillstånd skapad av kund",
           "approve_permit_extension_request": "Begäran om förlängning av tillstånd godkänd",
-          "cancel_permit_extension_request": "Begäran om förlängning av tillstånd avbruten"
+          "cancel_permit_extension_request": "Begäran om förlängning av tillstånd avbruten",
+          "create_draft_permit": "Tillståndet utkast skapat",
+          "update_draft_permit": "Tillståndet utkast uppdaterat"
         },
         "descriptions": {
           "update_permit": "Tillstånd uppdaterat",
@@ -79,7 +84,9 @@
           "create_admin_permit_extension_request": "Begäran om förlängning av tillstånd #{{relatedObject.id}} skapad av admin",
           "create_customer_permit_extension_request": "Begäran om förlängning av tillstånd #{{relatedObject.id}} skapad av kund",
           "approve_permit_extension_request": "Begäran om förlängning av tillstånd #{{relatedObject.id}} godkänd",
-          "cancel_permit_extension_request": "Begäran om förlängning av tillstånd #{{relatedObject.id}} avbruten"
+          "cancel_permit_extension_request": "Begäran om förlängning av tillstånd #{{relatedObject.id}} avbruten",
+          "create_draft_permit": "Tillståndet utkast skapat",
+          "update_draft_permit": "Tillståndet utkast uppdaterat"
         }
       },
       "dataTable": {
@@ -572,6 +579,7 @@
   "message": {
     "close": "Stänga",
     "error": "Fel",
+    "info": "Information",
     "unauthorized": "Du är inte behörig att se den här sidan"
   },
   "pages": {
@@ -593,8 +601,10 @@
       "permits": "Tillstånd",
       "residentPermit": "Parkeringstillstånd för boende",
       "save": "Spara",
+      "saveAsDraft": "Spara som utkast",
       "totalPrice": "Totalpris",
-      "createPermitError": "Det gick inte att skapa tillstånd"
+      "createPermitError": "Det gick inte att skapa tillstånd",
+      "draftPermitSaved": "Tillståndet {{permitId}} har sparats som utkast"
     },
     "editResidentPermit": {
       "cancelPayment": "Avbryt betalning",
@@ -613,7 +623,8 @@
       "permitId": "Tillstånds-ID",
       "permits": "Tillstånd",
       "residentParkingPermit": "Parkeringstillstånd för boende",
-      "title": "Sammanfattning"
+      "title": "Sammanfattning",
+      "loading": "Läser in..."
     },
     "login": {
       "login": "Logga in"
@@ -642,7 +653,9 @@
       "save": "Spara",
       "downloadPdf": "Ladda ner returnsinformation som PDF",
       "title": "Redigera Retur",
-      "ibanIsRequired": "IBAN-nummer krävs"
+      "ibanIsRequired": "IBAN-nummer krävs",
+      "loading": "Läser in...",
+      "noData": "Inga data"
     },
     "refunds": {
       "acceptRefunds": "Acceptera återbetalningar",
@@ -668,7 +681,8 @@
         "confirmTitle": "Bekräfta radering",
         "confirmMessage": "Adressen kommer att raderas permanent. Vill du fortsätta?",
         "confirm": "Radera",
-        "cancel": "Avbryt"
+        "cancel": "Avbryt",
+        "loading": "Läser in..."
       },
       "editLowEmissionCriterion": {
         "title": "Redigera kriterium för låga utsläpp",
@@ -682,7 +696,8 @@
         "confirmTitle": "Bekräfta radering",
         "confirmMessage": "Produkten kommer att raderas permanent. Vill du fortsätta?",
         "confirm": "Radera",
-        "cancel": "Avbryt"
+        "cancel": "Avbryt",
+        "loading": "Läser in..."
       },
       "lowEmissionCriteria": {
         "addNewCriterion": "Lägg till ett nytt kriterium för låga utsläpp",
@@ -728,6 +743,7 @@
   },
   "permitStatus": {
     "draft": "Utkast",
+    "preliminary": "Preliminär",
     "paymentInProgress": "Betalning pågår",
     "valid": "Giltigt",
     "cancelled": "Inställt",

--- a/src/pages/CreatePermit.tsx
+++ b/src/pages/CreatePermit.tsx
@@ -1,4 +1,4 @@
-import { Button } from 'hds-react';
+import { Button, IconPlusCircleFill } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
@@ -27,6 +27,7 @@ const CreatePermit = (): React.ReactElement => {
       />
       <Button
         className={styles.createButton}
+        iconLeft={<IconPlusCircleFill />}
         onClick={() => navigate(permitType)}>
         {t(`${T_PATH}.createPermit`)}
       </Button>

--- a/src/pages/CreateResidentPermit.tsx
+++ b/src/pages/CreateResidentPermit.tsx
@@ -382,7 +382,7 @@ const CreateResidentPermit = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -370,7 +370,7 @@ const EditResidentPermit = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/EditResidentPermit.tsx
+++ b/src/pages/EditResidentPermit.tsx
@@ -196,7 +196,7 @@ const EditResidentPermit = (): React.ReactElement => {
     fetchPolicy: 'no-cache',
     onCompleted: ({ permitDetail }) => {
       // permit parking zone should override customer
-      // zone as pre-selected vaule
+      // zone as pre-selected value
       const newCustomer = {
         ...permitDetail.customer,
         zone: permitDetail.parkingZone,

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -99,7 +99,7 @@ const EndPermit = (): React.ReactElement => {
   });
   const [endPermit] = useMutation<MutationResponse>(END_PERMIT_MUTATION);
   if (loading || !data) {
-    return <div>loading...</div>;
+    return <div>{t(`${T_PATH}.loading`)}</div>;
   }
   const { permitDetail } = data;
   const {

--- a/src/pages/EndPermit.tsx
+++ b/src/pages/EndPermit.tsx
@@ -184,7 +184,7 @@ const EndPermit = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/ExtendPermit.tsx
+++ b/src/pages/ExtendPermit.tsx
@@ -1,6 +1,7 @@
 import { gql, useLazyQuery, useMutation, useQuery } from '@apollo/client';
 import {
   Button,
+  IconArrowUndo,
   IconCheckCircleFill,
   Notification,
   NumberInput,
@@ -231,6 +232,7 @@ const ExtendResidentPermit = (): React.ReactElement => {
           <Button
             className={styles.actionButton}
             variant="secondary"
+            iconLeft={<IconArrowUndo />}
             onClick={navigateToDetailPage}>
             {t('cancelAndCloseWithoutSaving')}
           </Button>

--- a/src/pages/ExtendPermit.tsx
+++ b/src/pages/ExtendPermit.tsx
@@ -191,7 +191,7 @@ const ExtendResidentPermit = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -189,7 +189,7 @@ const Orders = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -1,5 +1,12 @@
 import { gql, useMutation, useQuery } from '@apollo/client';
-import { Button, IconDownload, IconPenLine, Notification } from 'hds-react';
+import {
+  Button,
+  IconArrowRightDashed,
+  IconCrossCircle,
+  IconDownload,
+  IconPenLine,
+  Notification,
+} from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
@@ -296,6 +303,7 @@ const PermitDetail = (): React.ReactElement => {
                   <Button
                     className={styles.actionButton}
                     variant="secondary"
+                    iconLeft={<IconArrowRightDashed />}
                     onClick={() => navigate('extend')}>
                     {t(`${T_PATH}.extend`)}
                   </Button>
@@ -315,6 +323,7 @@ const PermitDetail = (): React.ReactElement => {
                   <Button
                     className={styles.cancelButton}
                     variant="secondary"
+                    iconLeft={<IconCrossCircle />}
                     disabled={!canEndImmediately}
                     onClick={() => setOpenEndPermitDialog(true)}>
                     {t(`${T_PATH}.endPermit`)}

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -24,7 +24,12 @@ import TemporaryVehicle from '../components/permitDetail/TemporaryVehicle';
 import VehicleInfo from '../components/permitDetail/VehicleInfo';
 import useExportData from '../export/useExportData';
 import { formatExportUrlPdf } from '../export/utils';
-import { MutationResponse, PermitDetailData, PermitEndType } from '../types';
+import {
+  MutationResponse,
+  ParkingPermitStatus,
+  PermitDetailData,
+  PermitEndType,
+} from '../types';
 import { formatCustomerName, isPermitEditable } from '../utils';
 import styles from './PermitDetail.module.scss';
 
@@ -208,6 +213,18 @@ const PermitDetail = (): React.ReactElement => {
     }
   );
 
+  const handleEdit = () => {
+    const permit = data?.permitDetail;
+    if (
+      permit?.status === ParkingPermitStatus.DRAFT ||
+      permit?.status === ParkingPermitStatus.PRELIMINARY
+    ) {
+      navigate('create');
+    } else {
+      navigate('edit');
+    }
+  };
+
   const handleExport = () => {
     const url = formatExportUrlPdf('permit', id || '');
     exportData(url);
@@ -292,7 +309,7 @@ const PermitDetail = (): React.ReactElement => {
                     className={styles.actionButton}
                     iconLeft={<IconPenLine />}
                     disabled={!isPermitEditable(permitDetail)}
-                    onClick={() => navigate('edit')}>
+                    onClick={handleEdit}>
                     {t(`${T_PATH}.edit`)}
                   </Button>
                 )}

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -348,7 +348,7 @@ const PermitDetail = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/PermitDetail.tsx
+++ b/src/pages/PermitDetail.tsx
@@ -215,7 +215,7 @@ const PermitDetail = (): React.ReactElement => {
 
   let content = null;
   if (loading || !data) {
-    content = <div>loading...</div>;
+    content = <div>{t(`${T_PATH}.loading`)}</div>;
   } else {
     const { permitDetail } = data;
     const {

--- a/src/pages/Permits.tsx
+++ b/src/pages/Permits.tsx
@@ -258,7 +258,7 @@ const Permits = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -1,6 +1,13 @@
 import { gql, useMutation, useQuery } from '@apollo/client';
 import { Formik } from 'formik';
-import { Button, IconDownload, Notification, TextInput } from 'hds-react';
+import {
+  Button,
+  IconArrowUndo,
+  IconCheckCircle,
+  IconDownload,
+  Notification,
+  TextInput,
+} from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
@@ -181,6 +188,7 @@ const RefundDetail = (): React.ReactElement => {
                 {userRole > UserRole.PREPARATORS && (
                   <Button
                     className={styles.save}
+                    iconLeft={<IconCheckCircle />}
                     disabled={!(dirty && isValid)}
                     type="submit">
                     {t(`${T_PATH}.save`)}
@@ -197,6 +205,7 @@ const RefundDetail = (): React.ReactElement => {
                   <Button
                     variant="secondary"
                     className={styles.cancel}
+                    iconLeft={<IconArrowUndo />}
                     onClick={() => navigate('/refunds')}>
                     {t(`${T_PATH}.cancel`)}
                   </Button>

--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -214,7 +214,7 @@ const RefundDetail = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/RefundDetail.tsx
+++ b/src/pages/RefundDetail.tsx
@@ -83,11 +83,11 @@ const RefundDetail = (): React.ReactElement => {
   };
 
   if (loading) {
-    return <div>Loading..</div>;
+    return <div>{t(`${T_PATH}.loading`)}</div>;
   }
 
   if (!data) {
-    return <div>No data</div>;
+    return <div>{t(`${T_PATH}.noData`)}</div>;
   }
 
   const { name, iban } = data.refund;

--- a/src/pages/Refunds.tsx
+++ b/src/pages/Refunds.tsx
@@ -269,7 +269,7 @@ const Refunds = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/addresses/Addresses.tsx
+++ b/src/pages/superAdmin/addresses/Addresses.tsx
@@ -152,7 +152,7 @@ const Addresses = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/addresses/CreateAddress.tsx
+++ b/src/pages/superAdmin/addresses/CreateAddress.tsx
@@ -48,7 +48,7 @@ const CreateAddress = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -117,7 +117,7 @@ const EditAddress = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/addresses/EditAddress.tsx
+++ b/src/pages/superAdmin/addresses/EditAddress.tsx
@@ -78,7 +78,7 @@ const EditAddress = (): React.ReactElement => {
     deleteAddress({ variables: { addressId } });
   };
   if (loading) {
-    return <div>Loading...</div>;
+    return <div>{t(`${T_PATH}.loading`)}</div>;
   }
   return (
     <div className={styles.container}>

--- a/src/pages/superAdmin/announcements/CreateAnnouncement.tsx
+++ b/src/pages/superAdmin/announcements/CreateAnnouncement.tsx
@@ -48,7 +48,7 @@ const CreateAnnouncement = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/lowEmissionCriteria/CreateLowEmissionCriterion.tsx
+++ b/src/pages/superAdmin/lowEmissionCriteria/CreateLowEmissionCriterion.tsx
@@ -47,7 +47,7 @@ const CreateLowEmissionCriterion = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/lowEmissionCriteria/EditLowEmissionCriterion.tsx
+++ b/src/pages/superAdmin/lowEmissionCriteria/EditLowEmissionCriterion.tsx
@@ -118,7 +118,7 @@ const EditLowEmissionCriterion = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/lowEmissionCriteria/LowEmissionCriteria.tsx
+++ b/src/pages/superAdmin/lowEmissionCriteria/LowEmissionCriteria.tsx
@@ -130,7 +130,7 @@ const LowEmissionCriteria = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/products/CreateProduct.tsx
+++ b/src/pages/superAdmin/products/CreateProduct.tsx
@@ -48,7 +48,7 @@ const Products = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/products/EditProduct.tsx
+++ b/src/pages/superAdmin/products/EditProduct.tsx
@@ -118,7 +118,7 @@ const Products = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/pages/superAdmin/products/EditProduct.tsx
+++ b/src/pages/superAdmin/products/EditProduct.tsx
@@ -79,7 +79,7 @@ const Products = (): React.ReactElement => {
     deleteProduct({ variables: { productId } });
   };
   if (loading) {
-    return <div>Loading...</div>;
+    return <div>{t(`${T_PATH}.loading`)}</div>;
   }
   return (
     <div className={styles.container}>

--- a/src/pages/superAdmin/products/Products.tsx
+++ b/src/pages/superAdmin/products/Products.tsx
@@ -148,7 +148,7 @@ const Products = (): React.ReactElement => {
           dismissible
           closeButtonLabelText={t('message.close')}
           onClose={() => setErrorMessage('')}
-          style={{ zIndex: 100 }}>
+          style={{ zIndex: 100, opacity: 1 }}>
           {errorMessage}
         </Notification>
       )}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -69,6 +69,7 @@ const routes = [
       { path: 'permits/:id/end/:endType', element: <EndPermit /> },
       { path: 'permits/:id/edit/', element: <EditResidentPermit /> },
       { path: 'permits/:id/extend/', element: <ExtendPermit /> },
+      { path: 'permits/:id/create/', element: <CreateResidentPermit /> },
       { path: 'permits/create', element: <CreatePermit /> },
       { path: 'permits/create/resident', element: <CreateResidentPermit /> },
       { path: 'permits/create/company', element: <CreateCompanyPermit /> },

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -7,6 +7,8 @@ $color-cancelled-border: $color-suomenlinna-dark;
 $color-cancelled-fill: $color-suomenlinna-dark;
 $color-draft-border: $color-coat-of-arms;
 $color-draft-fill: $color-coat-of-arms-medium-light;
+$color-preliminary-border: $color-silver-dark;
+$color-preliminary-fill: $color-silver-medium-light;
 $color-payment-in-progress-border: $color-alert;
 $color-payment-in-progress-fill: $color-alert-light;
 $color-valid-border: $color-tram;

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,7 @@ export interface CustomerInput {
 }
 
 export interface PermitInput {
+  id?: number;
   contractType: string;
   customer: CustomerInput;
   vehicle: VehicleInput;

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,7 @@ export interface ParkingZone {
 
 export enum ParkingPermitStatus {
   DRAFT = 'DRAFT',
+  PRELIMINARY = 'PRELIMINARY',
   PAYMENT_IN_PROGRESS = 'PAYMENT_IN_PROGRESS',
   VALID = 'VALID',
   CANCELLED = 'CANCELLED',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,6 +258,7 @@ export function convertToCustomerInput(customer: Customer): CustomerInput {
 
 export function convertToPermitInput(permit: PermitDetail): PermitInput {
   const {
+    id,
     contractType,
     customer,
     vehicle,
@@ -273,6 +274,7 @@ export function convertToPermitInput(permit: PermitDetail): PermitInput {
   const vehicleInput = convertToVehicleInput(vehicle);
   const customerInput = convertToCustomerInput(customer);
   return {
+    id,
     contractType,
     customer: customerInput,
     vehicle: vehicleInput,


### PR DESCRIPTION
## Description

Allow draft permit creation for Admins.

Features / fixes / updates:
- Add draft-permit creation to create permit form
- Add HDS icons to buttons
- Add support for permit `PRELIMINARY`-status
- Hide ALL-status from permit forms
- Fix HDS Notification dialog layout
- Update fi/sv/en-translations

## Context

[PV-895](https://helsinkisolutionoffice.atlassian.net/browse/PV-895)

## How Has This Been Tested?

Manually through CreatePermitForm in Admin UI.

## Manual Testing Instructions for Reviewers

Test draft / preliminary permit creation from the Admin UI.
Note that this requires also these backend changes: https://github.com/City-of-Helsinki/parking-permits/pull/549

## Screenshots
![käsittelyhistoria ja napit](https://github.com/user-attachments/assets/8128abca-59b6-4060-8627-169f5dc64943)



[PV-895]: https://helsinkisolutionoffice.atlassian.net/browse/PV-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ