### PR TITLE
Added new Apollo client module to HDS Login

### DIFF
--- a/src/api/ApiClientProvider.tsx
+++ b/src/api/ApiClientProvider.tsx
@@ -3,10 +3,8 @@ import {
   ApolloProvider,
   NormalizedCacheObject,
 } from '@apollo/client';
-import { getApiTokensFromStorage, useApiTokensClientTracking } from 'hds-react';
 import React, { FC } from 'react';
-import { getEnv } from '../utils';
-import getApiClient from './client';
+import { useApolloClient } from '../hds/apolloClient/hooks';
 
 export interface ApiClientContextProps {
   readonly client: ApolloClient<NormalizedCacheObject>;
@@ -20,11 +18,6 @@ interface Props {
 }
 
 export const ApiClientProvider: FC<Props> = ({ children }) => {
-  useApiTokensClientTracking();
-  const tokens = getApiTokensFromStorage();
-  const apiToken = tokens
-    ? tokens[getEnv('REACT_APP_PARKING_PERMITS_AUDIENCE')]
-    : '';
-  const client = getApiClient(apiToken);
-  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  const clientInLogin = useApolloClient();
+  return <ApolloProvider client={clientInLogin}>{children}</ApolloProvider>;
 };

--- a/src/auth/LoginProvider.tsx
+++ b/src/auth/LoginProvider.tsx
@@ -1,6 +1,12 @@
+import { createHttpLink, InMemoryCache } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
 import { LoginProvider } from 'hds-react';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { getHDSClientConfig } from '.';
+import { TokenSetter } from '../hds/apolloClient';
+import { createApolloClientModule } from '../hds/apolloClient/apolloClientModule';
+import i18n from '../i18n';
+import { getEnv } from '../utils';
 
 interface HDSLoginProviderProps {
   children: React.ReactNode;
@@ -8,8 +14,40 @@ interface HDSLoginProviderProps {
 
 const HDSLoginProvider: FC<HDSLoginProviderProps> = ({ children }) => {
   const loginProviderProps = getHDSClientConfig();
+  const apolloClientModule = useMemo(() => {
+    const httpLink = createHttpLink({
+      uri: `${getEnv('REACT_APP_PARKING_PERMITS_BACKEND_URL')}/admin-graphql/`,
+    });
 
-  return <LoginProvider {...loginProviderProps}>{children}</LoginProvider>;
+    const authLink = setContext((_, { headers }) => ({
+      headers: {
+        ...headers,
+        'Accept-Language': i18n.language,
+        'Content-Language': i18n.language,
+      },
+    }));
+
+    const tokenSetter: TokenSetter = (headers, tokens) => {
+      const apiToken = tokens[getEnv('REACT_APP_PARKING_PERMITS_AUDIENCE')];
+      return {
+        authorization: apiToken ? `Bearer ${apiToken}` : '',
+      };
+    };
+
+    return createApolloClientModule({
+      tokenSetter,
+      clientOptions: {
+        link: authLink.concat(httpLink),
+        cache: new InMemoryCache(),
+      },
+    });
+  }, []);
+
+  return (
+    <LoginProvider {...loginProviderProps} modules={[apolloClientModule]}>
+      {children}
+    </LoginProvider>
+  );
 };
 
 export default HDSLoginProvider;

--- a/src/hds/README.md
+++ b/src/hds/README.md
@@ -1,0 +1,3 @@
+Files in this folder are copied from HDS, because they are not published yet.
+
+This folder can be removed when the ApolloClientModule can be imported from "hds-react".

--- a/src/hds/apolloClient/apolloClientModule.ts
+++ b/src/hds/apolloClient/apolloClientModule.ts
@@ -1,0 +1,97 @@
+import {
+  ApolloCache,
+  ApolloClient,
+  from,
+  HttpLink,
+  InMemoryCache,
+} from '@apollo/client/core';
+import { setContext } from '@apollo/client/link/context';
+import { createNamespacedBeacon } from 'hds-react';
+import {
+  ApolloClientModule,
+  apolloClientModuleEvents,
+  apolloClientModuleNamespace,
+  ApolloClientModuleProps,
+  defaultOptions,
+} from '.';
+import { createApiTokenClientTracker } from '../createApiTokenClientTracker';
+import { createAuthLink } from './authLink';
+
+/**
+ * IMPORTANT NOTICE:
+ *
+ * Apollo HttpLink converts all header keys to lower-case by default.
+ * To bypass this, the user has to provide a HttpLink and not to use options.uri, because HttpLink created here
+ * does not change the default behaviour.
+ *
+ * Example: new HttpLink({ uri, preserveHeaderCase: true }
+ *
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function createApolloClientModule<T = InMemoryCache>(
+  props: ApolloClientModuleProps<T>
+): ApolloClientModule<T> {
+  // custom beacon for sending signals in apolloClientModuleNamespace
+  const dedicatedBeacon = createNamespacedBeacon(apolloClientModuleNamespace);
+
+  const mergedProps: ApolloClientModuleProps<T> = {
+    ...defaultOptions,
+    ...props,
+  };
+
+  const {
+    clientOptions,
+    keepTokensWhileRenewing,
+    tokenSetter,
+    apiTokensWaitTime,
+    preventQueriesWhileRenewing,
+  } = mergedProps;
+
+  // tool for waiting for apiTokens and stopping awaits
+  const apiTokenTracker = createApiTokenClientTracker({
+    keepTokensWhileRenewing,
+    timeout: apiTokensWaitTime,
+  });
+
+  const { link, cache, uri, ...rest } = clientOptions;
+  const links = [link || new HttpLink({ uri })];
+  if (tokenSetter) {
+    links.unshift(
+      createAuthLink(tokenSetter, () => apiTokenTracker.getTokens())
+    );
+  }
+  if (preventQueriesWhileRenewing) {
+    links.unshift(
+      setContext(async (_, previousContext) => {
+        // waitForApiTokens() never rejects so not catching it.
+        await apiTokenTracker.waitForApiTokens();
+        return previousContext;
+      })
+    );
+  }
+
+  const clientProps = {
+    ...rest,
+    cache: (cache || new InMemoryCache()) as ApolloCache<T>,
+    link: from(links),
+  };
+  const client = new ApolloClient<T>(clientProps);
+
+  return {
+    namespace: apolloClientModuleNamespace,
+    connect: beacon => {
+      dedicatedBeacon.storeBeacon(beacon);
+      apiTokenTracker.connect(beacon);
+    },
+    getClient: () => client,
+    getTracker: () => apiTokenTracker,
+    reset: async () => {
+      dedicatedBeacon.emitEvent(
+        apolloClientModuleEvents.APOLLO_CLIENT_MODULE_RESET
+      );
+      apiTokenTracker.dispose();
+      client.stop();
+      await client.resetStore();
+    },
+  };
+}

--- a/src/hds/apolloClient/authLink.ts
+++ b/src/hds/apolloClient/authLink.ts
@@ -1,0 +1,24 @@
+import { ApolloLink } from '@apollo/client/core';
+import { TokenData } from 'hds-react';
+import { TokenSetter } from '.';
+
+// eslint-disable-next-line import/prefer-default-export
+export function createAuthLink(
+  tokenSetter: TokenSetter,
+  tokenGetter: () => TokenData
+): ApolloLink {
+  return new ApolloLink((operation, forward) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    operation.setContext(({ headers }) => {
+      const authHeaders = tokenSetter(headers, tokenGetter());
+      return {
+        headers: {
+          ...headers,
+          ...authHeaders,
+        },
+      };
+    });
+    return forward(operation);
+  });
+}

--- a/src/hds/apolloClient/hooks.ts
+++ b/src/hds/apolloClient/hooks.ts
@@ -1,0 +1,28 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { useConnectedModule } from 'hds-react';
+import { ApolloClientModule, apolloClientModuleNamespace } from './index';
+
+/**
+ * Returns the ApolloClient module.
+ * @returns ApolloClient
+ */
+export const useApolloClientModule = <
+  T = InMemoryCache
+>(): ApolloClientModule<T> => {
+  const apolloClientModule = useConnectedModule<ApolloClientModule<T>>(
+    apolloClientModuleNamespace
+  );
+  if (!apolloClientModule) {
+    throw new Error('Cannot find apolloClientModule from LoginContext.');
+  }
+  return apolloClientModule;
+};
+
+/**
+ * Returns the ApolloClient.
+ * @returns ApolloClient
+ */
+export const useApolloClient = <T = InMemoryCache>(): ApolloClient<T> => {
+  const apolloClientModule = useApolloClientModule<T>();
+  return apolloClientModule.getClient();
+};

--- a/src/hds/apolloClient/index.ts
+++ b/src/hds/apolloClient/index.ts
@@ -1,0 +1,70 @@
+import {
+  ApolloClient,
+  ApolloClientOptions,
+  InMemoryCache,
+} from '@apollo/client/core';
+import { ConnectedModule, TokenData } from 'hds-react';
+import { ApiTokenClientTracker } from '../createApiTokenClientTracker';
+
+export type TokenSetter = (
+  headers: Record<string, string>,
+  tokens: TokenData
+) => Record<string, string>;
+
+export type ApolloClientModule<T = InMemoryCache> = ConnectedModule & {
+  /**
+   * Returns the client.
+   */
+  getClient: () => ApolloClient<T>;
+  /**
+   * Returns the apiTokenClient tracker.
+   */
+  getTracker: () => ApiTokenClientTracker;
+  /**
+   * Resets the client and apiTokenTracker.
+   */
+  reset: () => Promise<void>;
+};
+
+export type ApolloClientModuleProps<T = InMemoryCache> = {
+  /**
+   * How long in milliseconds should api tokens be awaited before rejecting a query.
+   * Default 15 000, set in createApiTokenClientTracker.
+   */
+  apiTokensWaitTime?: number;
+  /**
+   * Function to return tokens appended to the headers
+   * @param {headers} Current headers in the request
+   * @param {tokens} All tokens from the apiTokenClient
+   */
+  tokenSetter?: TokenSetter;
+  /**
+   * Options for the ApolloClient. If "uri" option is given, a HttpLink is automatically created from it.
+   * The module adds its own AplloLink(s) before other links.
+   * Default cache is InMemoryCache.
+   */
+  clientOptions: Partial<ApolloClientOptions<T>>;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts.
+   * Default true, set in createApiTokenClientTracker.
+   */
+  keepTokensWhileRenewing?: boolean;
+  /**
+   * If true, a ApolloLink is added to wait for possible api token renewal to end.
+   * If false, there might be times when queries are made with old api tokens. Unlikely, but possible.
+   * Default true.
+   */
+  preventQueriesWhileRenewing?: boolean;
+};
+
+export const apolloClientModuleEvents = {
+  APOLLO_CLIENT_MODULE_RESET: 'APOLLO_CLIENT_MODULE_RESET',
+} as const;
+
+export type ApolloClientModuleEvent = keyof typeof apolloClientModuleEvents;
+
+export const apolloClientModuleNamespace = 'apolloClient';
+
+export const defaultOptions: Partial<ApolloClientModuleProps> = {
+  preventQueriesWhileRenewing: true,
+};

--- a/src/hds/createApiTokenClientTracker.ts
+++ b/src/hds/createApiTokenClientTracker.ts
@@ -1,0 +1,301 @@
+import {
+  ApiTokenClient,
+  apiTokensClientError,
+  apiTokensClientEvents,
+  apiTokensClientNamespace,
+  Beacon,
+  createTriggerPropsForAllApiTokensClientSignals,
+  Disposer,
+  errorSignalType,
+  eventSignalType,
+  getApiTokensClientEventPayload,
+  isApiTokensFetchFailedErrorSignal,
+  isApiTokensRemovedSignal,
+  isApiTokensRenewalStartedSignal,
+  isApiTokensUpdatedSignal,
+  isInitSignal,
+  isInvalidApiTokensErrorSignal,
+  Signal,
+  SignalListener,
+  SignalTriggerProps,
+  TokenData,
+  waitForSignals,
+} from 'hds-react';
+
+// copy of lodash.uniqueId
+let counter = 0;
+const uniqueId = () => {
+  counter += 1;
+  return counter;
+};
+
+// copy of lodash.noop
+const noop = () => undefined;
+
+type ApiTokenClientTrackerProps = {
+  /**
+   * How long to wait for apitoken renewal to fulfill. Default 15000ms.
+   */
+  timeout?: number;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts. Default true.
+   */
+  keepTokensWhileRenewing?: boolean;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts. Default false.
+   */
+  keepTokensAfterRenewalError?: boolean;
+  /**
+   * Type of the signal that should end the pending api token renewal promise.
+   * Usually it is a clear/dispose signal from the module using this util, so the promise is fulfilled when the module is not used anymore.
+   */
+  rejectionSignalTrigger?: SignalTriggerProps;
+  /**
+   * Called when api tokens change. Not called when dispose() is called.
+   */
+  onChange?: (tokens: TokenData, changeTrigger: Signal) => void;
+};
+
+export type ApiTokenClientTracker = {
+  /**
+   * Connect the utility to a beacon
+   */
+  connect: (connectedBeacon: Beacon) => void;
+  /**
+   * Get current tokens
+   */
+  getTokens: () => TokenData;
+  /**
+   * Dispose listeners, references and data
+   */
+  dispose: Disposer;
+  /**
+   * Discards pending promise for api token renewal.
+   * Emits signal to abort it. Same signal is used in all instance of this utility, so the signal stops them all.
+   */
+  stopWaitingForTokens: Disposer;
+  /**
+   * Returns the pending renewal promise or immediately resolved promise.
+   * Never rejects, the returned boolean indicates was the promise successful.
+   */
+  waitForApiTokens: () => Promise<boolean>;
+  /**
+   * Returns true, if renewal process is on-going
+   */
+  isRenewing: () => boolean;
+};
+
+type InnerState = {
+  tokens: TokenData;
+  disposer: Disposer;
+  renewalPromise: Promise<boolean> | null;
+  beacon: Beacon | null;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+};
+
+/**
+ * Utility for tracking changes in the apiTokenClient module
+ * Use it in the connect() function of any ConnectedModule.
+ * @param {ApiTokenClientTrackerProps}
+ * @returns {ApiTokenClientTracker}
+ */
+
+const defaultApiTokenTimeoutInMs = 15000;
+export function createApiTokenClientTracker({
+  timeout = defaultApiTokenTimeoutInMs,
+  keepTokensWhileRenewing = true,
+  keepTokensAfterRenewalError = false,
+  rejectionSignalTrigger,
+  onChange,
+}: ApiTokenClientTrackerProps): ApiTokenClientTracker {
+  const innerState: InnerState = {
+    tokens: {},
+    disposer: noop,
+    renewalPromise: null,
+    beacon: null,
+    timeoutId: null,
+  };
+
+  const isRenewing = () => !!innerState.renewalPromise;
+
+  // self triggered and self listened signal to stop listening renewals
+  // must be unique so other listeners in other instances of this utils are not cancelled.
+  const signalTypeToRejectApiTokenAwait = `REJECT_API_TOKEN_AWAIT_${uniqueId()}`;
+  const clearPromiseTimeOut = () => {
+    if (innerState.timeoutId) {
+      clearTimeout(innerState.timeoutId);
+      innerState.timeoutId = null;
+    }
+  };
+  const markRenewalCompleted = () => {
+    clearPromiseTimeOut();
+    innerState.renewalPromise = null;
+  };
+
+  const updateTokens = (
+    tokens: TokenData | null = null,
+    changeTrigger: Signal
+  ) => {
+    innerState.tokens = tokens || {};
+    if (onChange) {
+      onChange(innerState.tokens, changeTrigger);
+    }
+  };
+
+  const updateInnerRenewalState = (
+    changeTrigger: Signal,
+    tokens: TokenData | null = null
+  ) => {
+    const renewalStarted = isApiTokensRenewalStartedSignal(changeTrigger);
+    if (renewalStarted) {
+      if (!keepTokensWhileRenewing) {
+        updateTokens({}, changeTrigger);
+      }
+    } else {
+      markRenewalCompleted();
+    }
+    if (tokens) {
+      updateTokens(tokens, changeTrigger);
+    }
+  };
+  const createRenewalPromise = async (
+    timeoutDelay: number
+  ): Promise<boolean> => {
+    if (!innerState.beacon) {
+      return Promise.reject(
+        new Error('No Beacon found for api token renewal.')
+      );
+    }
+
+    const promiseRejectionSignals: Array<Signal> = [
+      {
+        type: eventSignalType,
+        payload: { type: signalTypeToRejectApiTokenAwait },
+      },
+      {
+        type: errorSignalType,
+        payload: { type: apiTokensClientError.API_TOKEN_FETCH_FAILED },
+      },
+      {
+        type: errorSignalType,
+        payload: { type: apiTokensClientError.INVALID_API_TOKENS },
+      },
+    ];
+    if (rejectionSignalTrigger) {
+      promiseRejectionSignals.push(rejectionSignalTrigger as unknown as Signal);
+    }
+    const signalPromise = waitForSignals(
+      innerState.beacon,
+      [{ payload: { type: apiTokensClientEvents.API_TOKENS_UPDATED } }],
+      {
+        rejectOn: promiseRejectionSignals,
+      }
+    );
+
+    const timeoutPromise = timeoutDelay
+      ? new Promise((resolve, reject) => {
+          innerState.timeoutId = setTimeout(() => {
+            reject(new Error('Timeout for waitForApiTokens() reached'));
+            innerState.timeoutId = null;
+          }, timeoutDelay);
+        })
+      : null;
+
+    // The promise never rejects to make handling more simpler
+    return (
+      timeoutPromise
+        ? Promise.race([signalPromise, timeoutPromise])
+        : signalPromise
+    )
+      .then(() => Promise.resolve(true))
+      .catch(() => Promise.resolve(false));
+  };
+
+  const startWaitingForRenewal = (trigger: Signal) => {
+    updateInnerRenewalState(trigger);
+    innerState.renewalPromise = createRenewalPromise(timeout);
+    innerState.renewalPromise.then(() => {
+      markRenewalCompleted();
+    });
+  };
+
+  const listener: SignalListener = signal => {
+    if (isInitSignal(signal)) {
+      const apiTokensClient = signal.context as ApiTokenClient;
+      // fail safe if signals are mixed.
+      if (!apiTokensClient) {
+        return;
+      }
+      if (apiTokensClient.isRenewing()) {
+        startWaitingForRenewal(signal);
+      }
+      updateTokens(apiTokensClient.getTokens() || {}, signal);
+      return;
+    }
+    if (isApiTokensRenewalStartedSignal(signal)) {
+      startWaitingForRenewal(signal);
+      return;
+    }
+    if (
+      isApiTokensFetchFailedErrorSignal(signal) ||
+      isInvalidApiTokensErrorSignal(signal)
+    ) {
+      updateInnerRenewalState(signal, keepTokensAfterRenewalError ? null : {});
+      return;
+    }
+    if (isApiTokensUpdatedSignal(signal)) {
+      const payload = getApiTokensClientEventPayload(signal);
+      const newTokens = (payload && (payload.data as TokenData)) || {};
+      updateInnerRenewalState(signal, newTokens);
+      return;
+    }
+    if (!keepTokensWhileRenewing && isApiTokensRemovedSignal(signal)) {
+      updateTokens({}, signal);
+    }
+  };
+
+  const emitApiTokenAwaitRejectionSignal = () => {
+    if (!innerState.renewalPromise || !innerState.beacon) {
+      return;
+    }
+    innerState.beacon.emit({
+      type: eventSignalType,
+      namespace: apiTokensClientNamespace,
+      payload: { type: signalTypeToRejectApiTokenAwait },
+    });
+  };
+
+  const dispose = () => {
+    emitApiTokenAwaitRejectionSignal();
+    clearPromiseTimeOut();
+    innerState.disposer();
+    innerState.disposer = noop;
+    innerState.beacon = null;
+    innerState.renewalPromise = null;
+    innerState.tokens = {};
+  };
+
+  return {
+    connect: (connectedBeacon: Beacon) => {
+      dispose();
+      innerState.beacon = connectedBeacon;
+      innerState.disposer = connectedBeacon.addListener(
+        createTriggerPropsForAllApiTokensClientSignals(),
+        listener
+      );
+    },
+    getTokens: () => innerState.tokens,
+    stopWaitingForTokens: () => {
+      clearPromiseTimeOut();
+      emitApiTokenAwaitRejectionSignal();
+    },
+    isRenewing,
+    waitForApiTokens: () => {
+      if (isRenewing()) {
+        return innerState.renewalPromise as Promise<boolean>;
+      }
+      return Promise.resolve(true);
+    },
+    dispose,
+  };
+}


### PR DESCRIPTION
## Description

The module is created and tested in HDS, but not released yet, so copied it.

The module adds automatically two ApolloLinks:
- one that appends auth headers
- one that awaits for api token renewal to end if it happens to be in progress at the same time

The created ApolloClient is passed to the ApolloClient context.

## How Has This Been Tested?

HDS has unit tests and tested locally by keeping admin ui open for 60+minutes and checking tokens are renewed and queries work.

## Manual Testing Instructions for Reviewers
