### PR TITLE
fix: issues caused by api token renewal

### DIFF
--- a/src/api/useApiToken.tsx
+++ b/src/api/useApiToken.tsx
@@ -1,9 +1,0 @@
-import { getApiTokensFromStorage } from 'hds-react';
-import { getEnv } from '../utils';
-
-const useApiToken = (): string => {
-  const tokens = getApiTokensFromStorage();
-  return tokens ? tokens[getEnv('REACT_APP_PARKING_PERMITS_AUDIENCE')] : '';
-};
-
-export default useApiToken;

--- a/src/api/useUserRole.tsx
+++ b/src/api/useUserRole.tsx
@@ -1,5 +1,5 @@
+import { useAuthenticatedUser } from 'hds-react';
 import { decode } from 'jsonwebtoken';
-import useApiToken from './useApiToken';
 
 export enum Groups {
   SUPER_ADMIN = 'sg_kymp_pyva_asukpt_yllapito',
@@ -22,8 +22,8 @@ export enum UserRole {
 }
 
 const useUserRole = (): UserRole => {
-  const apiToken = useApiToken();
-  const decodedToken = decode(apiToken);
+  const user = useAuthenticatedUser();
+  const decodedToken = user && decode(user.id_token);
   if (decodedToken) {
     const adGroups: string[] = [];
     // Remove special ADFS-prefix

--- a/src/api/waitForApiToken.ts
+++ b/src/api/waitForApiToken.ts
@@ -1,0 +1,32 @@
+import { getApiTokensFromStorage } from 'hds-react';
+import { getEnv } from '../utils';
+
+const RETRY_TIME_MS = 200;
+const MAX_RETRY_ATTEMPTS = 10;
+
+const wait = (waitForMs: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(() => resolve(), waitForMs);
+  });
+
+const getApiToken = () => {
+  const tokens = getApiTokensFromStorage();
+  return tokens
+    ? tokens[getEnv('REACT_APP_PARKING_PERMITS_AUDIENCE')]
+    : undefined;
+};
+
+const waitForApiToken = async (): Promise<string> => {
+  const retryAttempts = 0;
+  while (retryAttempts <= MAX_RETRY_ATTEMPTS) {
+    const apiToken = getApiToken();
+    if (apiToken) {
+      return apiToken;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await wait(RETRY_TIME_MS);
+  }
+  throw new Error('Failed to get API token');
+};
+
+export default waitForApiToken;

--- a/src/export/useExportData.tsx
+++ b/src/export/useExportData.tsx
@@ -1,16 +1,18 @@
 import { useTranslation } from 'react-i18next';
-import useApiToken from '../api/useApiToken';
+import waitForApiToken from '../api/waitForApiToken';
 
 const useExportData = (): ((url: string | URL) => void) => {
   const { i18n } = useTranslation();
-  const token = useApiToken();
   return (url: string | URL) => {
-    fetch(url, {
-      headers: {
-        authorization: token ? `Bearer ${token}` : '',
-        'Accept-Language': i18n.language,
-      },
-    })
+    waitForApiToken()
+      .then(apiToken =>
+        fetch(url, {
+          headers: {
+            authorization: apiToken ? `Bearer ${apiToken}` : '',
+            'Accept-Language': i18n.language,
+          },
+        })
+      )
       .then(response => response.blob())
       .then(blob => {
         const file = window.URL.createObjectURL(blob);


### PR DESCRIPTION
1) useUserRole depended on useApiToken to determine user role. Since useApiToken can return empty token during token renewal, this would cause spurious issues with user receiving a wrong role. Resolved by using user id token instead of api token to access user's AD groups.

2) useExportData relied on useApiToken to do a fetch request. Added an async helper function watForApiToken that waits up to 2 seconds for the apiToken to become available.

refs: HDS-2615

