### PR TITLE
fix: use lazy query in address pagination

### DIFF
--- a/src/pages/superAdmin/addresses/Addresses.tsx
+++ b/src/pages/superAdmin/addresses/Addresses.tsx
@@ -1,4 +1,4 @@
-import { gql, useQuery } from '@apollo/client';
+import { gql, useLazyQuery } from '@apollo/client';
 import classNames from 'classnames';
 import { Button, Notification } from 'hds-react';
 import React, { useState } from 'react';
@@ -75,14 +75,12 @@ const Addresses = (): React.ReactElement => {
     orderBy,
   };
 
-  const { loading, data, refetch } = useQuery<AddressesQueryData>(
-    ADDRESSES_QUERY,
-    {
+  const [getAddresses, { loading, data, refetch }] =
+    useLazyQuery<AddressesQueryData>(ADDRESSES_QUERY, {
       variables,
       fetchPolicy: 'no-cache',
       onError: error => setErrorMessage(error.message),
-    }
-  );
+    });
 
   const handleSearch = (newSearchParams: AddressSearchParams) => {
     setSearchParams(
@@ -94,10 +92,12 @@ const Addresses = (): React.ReactElement => {
       { replace: true }
     );
 
-    refetch({
-      searchParams: newSearchParams,
-      pageInput: { page: 1 },
-      orderBy,
+    getAddresses({
+      variables: {
+        searchParams: newSearchParams,
+        pageInput: { page: 1 },
+        orderBy,
+      },
     });
   };
 


### PR DESCRIPTION
## Description

Address pagination did not work well when used together with the address search.
Change address form to use Apollo client lazy queries to remedy this behaviour.

## Context

[PV-843](https://helsinkisolutionoffice.atlassian.net/browse/PV-843)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Test that address pagination works together with different searches.

## Screenshots

![address pagination fixed](https://github.com/user-attachments/assets/e7ab7359-51f7-4bab-a093-6b73ee8e1efb)



[PV-843]: https://helsinkisolutionoffice.atlassian.net/browse/PV-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ