### PR TITLE
Remove 2 week limit for temporary vehicle

### DIFF
--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -105,7 +105,6 @@ const TemporaryVehicle = ({
                       label={t(`${T_PATH}.registrationNumber.label`)}
                       onChange={handleChange}
                       className="registration-input"
-                      helperText={t(`${T_PATH}.registrationNumber.helpText`)}
                     />
                   )}
                 </Field>
@@ -145,10 +144,6 @@ const TemporaryVehicle = ({
                       id="endDate"
                       className="date-input"
                       minDate={form.getFieldProps('startDate').value}
-                      maxDate={addWeeks(
-                        form.getFieldProps('startDate').value,
-                        2
-                      )}
                       initialMonth={form.getFieldProps('startDate').value}
                       value={format(field.value, 'd.M.yyyy')}
                       onChange={(value: string, valueAsDate: Date) =>


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Remove 2 week limit for temporary vehicle

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

In admin ui it is now possible to add temporary vehicle without time constraint.

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->
Tested manually.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->
Temporary vehicle should now be possible to add for any duration.

## Screenshots

<!-- Add screenshots if appropriate -->
