### PR TITLE
fix: add language-support for calendars

### DIFF
--- a/src/components/orders/OrdersSearch.tsx
+++ b/src/components/orders/OrdersSearch.tsx
@@ -10,6 +10,7 @@ import {
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  Language,
   OrderSearchParams,
   PaymentType,
   PermitContractType,
@@ -31,7 +32,7 @@ const OrdersSearch = ({
   searchParams,
   onSubmit,
 }: OrdersSearchProps): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const [query, setQuery] = useState(searchParams.q);
   const [startDate, setStartDate] = useState(searchParams.startDate);
@@ -93,6 +94,7 @@ const OrdersSearch = ({
             id="startDate"
             className={styles.startDate}
             label={t(`${T_PATH}.startDate`)}
+            language={i18n.language as Language}
             value={startDate}
             onChange={setStartDate}
           />
@@ -101,6 +103,7 @@ const OrdersSearch = ({
             id="endDate"
             className={styles.endDate}
             label={t(`${T_PATH}.endDate`)}
+            language={i18n.language as Language}
             value={endDate}
             onChange={setEndDate}
           />

--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -14,7 +14,7 @@ import {
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
-import { PermitDetail } from '../../types';
+import { Language, PermitDetail } from '../../types';
 import styles from './TemporaryVehicle.module.scss';
 
 const T_PATH = 'components.permitDetail.temporaryVehicle';
@@ -121,7 +121,7 @@ const TemporaryVehicle = ({
                         form.setFieldValue('startDate', valueAsDate)
                       }
                       label={t(`${T_PATH}.startDate`)}
-                      language={(i18n?.language || 'fi') as 'fi' | 'sv' | 'en'}
+                      language={i18n.language as Language}
                     />
                   )}
                 </Field>
@@ -150,7 +150,7 @@ const TemporaryVehicle = ({
                         form.setFieldValue('endDate', valueAsDate)
                       }
                       label={t(`${T_PATH}.endDate`)}
-                      language={(i18n?.language || 'fi') as 'fi' | 'sv' | 'en'}
+                      language={i18n.language as Language}
                     />
                   )}
                 </Field>

--- a/src/components/refunds/RefundsSearch.tsx
+++ b/src/components/refunds/RefundsSearch.tsx
@@ -2,7 +2,7 @@ import { formatISO, parse } from 'date-fns';
 import { Button, DateInput, IconSearch, SearchInput } from 'hds-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PaymentType, RefundSearchParams } from '../../types';
+import { Language, PaymentType, RefundSearchParams } from '../../types';
 import { joinSet } from '../../utils';
 import FilterOptions from '../orders/FilterOptions';
 import styles from './RefundsSearch.module.scss';
@@ -19,7 +19,7 @@ const RefundsSearch = ({
   searchParams,
   onSearch,
 }: RefundsSearchProps): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const [status, setStatus] = useState(searchParams.status);
   const [query, setQuery] = useState(searchParams.q);
@@ -55,6 +55,7 @@ const RefundsSearch = ({
           <DateInput
             className={styles.startDate}
             id="startDate"
+            language={i18n.language as Language}
             value={startDate}
             onChange={setStartDate}
           />
@@ -62,6 +63,7 @@ const RefundsSearch = ({
           <DateInput
             className={styles.endDate}
             id="endDate"
+            language={i18n.language as Language}
             value={endDate}
             onChange={setEndDate}
           />

--- a/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.tsx
+++ b/src/components/superAdmin/lowEmissionCriteria/LowEmissionCriterionForm.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line import/no-namespace
 import * as Yup from 'yup';
-import { LowEmissionCriterion } from '../../../types';
+import { Language, LowEmissionCriterion } from '../../../types';
 import { formatDateDisplay } from '../../../utils';
 import EuroClassSelect from '../../common/EuroClassSelect';
 import styles from './LowEmissionCriterionForm.module.scss';
@@ -28,7 +28,7 @@ const LowEmissionCriterionForm = ({
   onDelete,
   onCancel,
 }: LowEmissionCriterionFormProps): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const initialValues = criterion
     ? {
         nedcMaxEmissionLimit: criterion.nedcMaxEmissionLimit,
@@ -127,6 +127,7 @@ const LowEmissionCriterionForm = ({
                     id={field.name}
                     className={styles.field}
                     label={t(`${T_PATH}.startDate`)}
+                    language={i18n.language as Language}
                     value={field.value && formatDateDisplay(field.value)}
                     onChange={(_, date) => form.setFieldValue(field.name, date)}
                     errorText={
@@ -142,6 +143,7 @@ const LowEmissionCriterionForm = ({
                     id={field.name}
                     className={styles.field}
                     label={t(`${T_PATH}.endDate`)}
+                    language={i18n.language as Language}
                     value={field.value && formatDateDisplay(field.value)}
                     onChange={(_, date) => form.setFieldValue(field.name, date)}
                     errorText={

--- a/src/components/superAdmin/products/ProductForm.tsx
+++ b/src/components/superAdmin/products/ProductForm.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line import/no-namespace
 import * as Yup from 'yup';
 import {
+  Language,
   ParkingZone,
   ProductInput,
   ProductType,
@@ -201,6 +202,7 @@ const ProductForm = ({
                     className={styles.field}
                     id="startDate"
                     label={t(`${T_PATH}.startDate`)}
+                    language={i18n.language as Language}
                     value={formatDateDisplay(field.value)}
                     onChange={(_, date) =>
                       form.setFieldValue(
@@ -220,6 +222,7 @@ const ProductForm = ({
                     className={styles.field}
                     id="endDate"
                     label={t(`${T_PATH}.endDate`)}
+                    language={i18n.language as Language}
                     value={formatDateDisplay(field.value)}
                     onChange={(_, date) =>
                       form.setFieldValue(


### PR DESCRIPTION
## Description

Add language-support for calendars in:
- OrdersSearch
- TemporaryVehicle
- RefundsSearch
- LowEmissionCriterionForm
- ProductForm

Refs: SHPPWS-85

## Screenshots

![orders](https://github.com/user-attachments/assets/d6cb7b1c-cc46-4d4a-af9c-37ffaf3bc9a9)

