### PR TITLE
SHPPWS-28: Fix announcement timestamp

### DIFF
--- a/src/pages/superAdmin/announcements/Announcements.tsx
+++ b/src/pages/superAdmin/announcements/Announcements.tsx
@@ -8,6 +8,7 @@ import DataTable from '../../../components/common/DataTable';
 import { Column } from '../../../components/types';
 import { useOrderByParam, usePageParam } from '../../../hooks/searchParam';
 import { Announcement, AnnouncementsQueryData, OrderBy } from '../../../types';
+import { formatDateTimeDisplayWithoutSeconds } from '../../../utils';
 import styles from './Announcements.module.scss';
 
 const T_PATH = 'pages.superAdmin.announcements';
@@ -112,7 +113,7 @@ const Announcements = (): React.ReactElement => {
       name: t(`${T_PATH}.sentAt`),
       field: 'createdAt',
       selector: ({ createdAt }) =>
-        new Date(createdAt).toLocaleString(i18n.language),
+        formatDateTimeDisplayWithoutSeconds(createdAt),
       sortable: true,
     },
   ];

--- a/src/pages/superAdmin/announcements/ViewAnnouncement.tsx
+++ b/src/pages/superAdmin/announcements/ViewAnnouncement.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import { makePrivate } from '../../../auth/utils';
 import { Announcement } from '../../../types';
+import { formatDateTimeDisplayWithoutSeconds } from '../../../utils';
 import styles from './ViewAnnouncement.module.scss';
 
 const T_PATH = 'pages.superAdmin.announcement';
@@ -77,7 +78,11 @@ const ViewAnnouncement = (): React.ReactElement => {
             </div>
             <div className={styles.col}>
               <p className="text-medium">{t(`${T_PATH}.sentAt`)}</p>
-              <p>{data.announcement.createdAt}</p>
+              <p>
+                {formatDateTimeDisplayWithoutSeconds(
+                  data.announcement.createdAt
+                )}
+              </p>
             </div>
           </div>
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,6 +135,19 @@ export function formatDateTimeDisplay(datetime: string | Date): string {
   return dt ? dt.toLocaleString(i18n.language) : '';
 }
 
+export function formatDateTimeDisplayWithoutSeconds(
+  createdAt: string | Date
+): string {
+  const i18n = getI18n();
+  return new Date(createdAt).toLocaleString(i18n.language, {
+    hour: '2-digit',
+    minute: '2-digit',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+}
+
 export function formatCustomerName(customer: Customer): string {
   const { firstName, lastName } = customer;
   return `${lastName}, ${firstName}`;


### PR DESCRIPTION
Refs SHPPWS-28 / Zendesk ticket 27942

## Description

This formats timestamps in Announcements list and when viewing the announcement.

## Screenshots

After change when listing announcements:
<img width="1645" alt="shppws-28-list-announcements" src="https://github.com/user-attachments/assets/aebf7ce8-4d86-42d5-adb6-d26899d0700a" />

After change when viewing announcement:
<img width="1638" alt="shppws-28-view-announcement" src="https://github.com/user-attachments/assets/a6ae0617-7015-4dba-9e11-c97bc1dbdc2d" />

## How Has This Been Tested?

Manual testing in local development environment.