### PR TITLE
SHPPWS-54: Remove fixed positions from the form buttons

### DIFF
--- a/src/components/residentPermit/EditResidentPermitForm.module.scss
+++ b/src/components/residentPermit/EditResidentPermitForm.module.scss
@@ -21,7 +21,6 @@
 .footer {
   padding: $spacing-m $spacing-s;
   box-shadow: 0 -5px 5px -5px $color-black-30;
-  position: fixed;
   width: 99%;
   left: 0;
   bottom: 0;

--- a/src/components/residentPermit/EditResidentPermitPreview.module.scss
+++ b/src/components/residentPermit/EditResidentPermitPreview.module.scss
@@ -20,7 +20,6 @@
 .footer {
   padding: $spacing-m $spacing-s;
   box-shadow: 0 -5px 5px -5px $color-black-30;
-  position: fixed;
   width: 99%;
   left: 0;
   bottom: 0;

--- a/src/pages/CreateResidentPermit.module.scss
+++ b/src/pages/CreateResidentPermit.module.scss
@@ -29,7 +29,6 @@
   .footer {
     padding: $spacing-m $spacing-s;
     box-shadow: 0 -5px 5px -5px $color-black-30;
-    position: fixed;
     width: 99%;
     left: 0;
     bottom: 0;

--- a/src/pages/EndPermit.module.scss
+++ b/src/pages/EndPermit.module.scss
@@ -24,7 +24,6 @@
 .actions {
   padding: $spacing-m 0;
   box-shadow: 0 -5px 5px -5px $color-black-30;
-  position: fixed;
   width: 100%;
   max-width: $breakpoint-xl;
   left: calc(100% - #{$breakpoint-xl}) / 2;

--- a/src/pages/ExtendPermit.module.scss
+++ b/src/pages/ExtendPermit.module.scss
@@ -11,7 +11,6 @@
 .footer {
   padding: $spacing-m $spacing-s;
   box-shadow: 0 -5px 5px -5px $color-black-30;
-  position: fixed;
   width: 99%;
   left: 0;
   bottom: 0;

--- a/src/pages/PermitDetail.module.scss
+++ b/src/pages/PermitDetail.module.scss
@@ -43,7 +43,6 @@
   .footer {
     padding: $spacing-m 0;
     box-shadow: 0 -5px 5px -5px $color-black-30;
-    position: fixed;
     width: 100%;
     max-width: $breakpoint-xl;
     left: calc(100% - #{$breakpoint-xl}) / 2;

--- a/src/pages/Refunds.module.scss
+++ b/src/pages/Refunds.module.scss
@@ -7,7 +7,6 @@
   .footer {
     padding: $spacing-m 0;
     box-shadow: 0 -5px 5px -5px $color-black-30;
-    position: fixed;
     width: 100%;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
## Description

Remove fixed positions from the form buttons.
This prevents button overlaps with the page footer-component.

## Screenshots

![Admin UI footer fixed](https://github.com/user-attachments/assets/af4aa070-14c4-401c-9db3-81a1db787f0c)
