### PR TITLE
SHPPWS-93: Update end permit dialog messages and date format

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -181,7 +181,7 @@
       },
       "endPermitDialog": {
         "cancel": "Cancel",
-        "choosePermitEndType": "Choose when to cancel the permit",
+        "choosePermitEndType": "Choose when the permit is ended (refunds will be generated automatically for the remaining paid months of the permit):",
         "continue": "Continue",
         "endAfterCurrentPeriod": "End permit after current period",
         "endImmediately": "End permit immediately",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -181,7 +181,7 @@
       },
       "endPermitDialog": {
         "cancel": "Peruuta",
-        "choosePermitEndType": "Valitsen milloin tunnuksen voimassaolo päättyy",
+        "choosePermitEndType": "Valitse milloin tunnuksen voimassaolo päättyy (kokonaisista tunnuksen jäljellä olevista maksetuista kuukausista muodostetaan palautukset automaattisesti):",
         "continue": "Jatka",
         "endAfterCurrentPeriod": "Päätä tunnus kuluvan tilausjakson päätteeksi",
         "endImmediately": "Päätä tunnus välittömästi",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -181,7 +181,7 @@
       },
       "endPermitDialog": {
         "cancel": "Avbryt",
-        "choosePermitEndType": "Välj när tillståndet upphör",
+        "choosePermitEndType": "Välj när tillståndet upphör (återbetalningar genereras automatiskt för de återstående betalda månaderna av tillståndet):",
         "continue": "Fortsätt",
         "endAfterCurrentPeriod": "Sluttillstånd efter aktuell period",
         "endImmediately": "Avsluta tillstånd omedelbart",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { addMonths } from 'date-fns';
+import { addMonths, format } from 'date-fns';
 import { extractIBAN } from 'ibantools';
 import { getI18n } from 'react-i18next';
 import {
@@ -16,6 +16,8 @@ import {
   Vehicle,
   VehicleInput,
 } from './types';
+
+const dateFormat = 'd.M.yyyy HH:mm';
 
 type TranslateFunction = (name: string) => string;
 
@@ -130,9 +132,8 @@ export function formatPermitMaxValidPeriodInMonths(
 }
 
 export function formatDateTimeDisplay(datetime: string | Date): string {
-  const i18n = getI18n();
   const dt = typeof datetime === 'string' ? new Date(datetime) : datetime;
-  return dt ? dt.toLocaleString(i18n.language) : '';
+  return format(dt, dateFormat);
 }
 
 export function formatDateTimeDisplayWithoutSeconds(


### PR DESCRIPTION
## Description

Updates:
- Update permit end dialog fi/sv/en-messages
- Update date format to match other date formats in the application

## Test-case

Open-ended permit validity period: 20.3.2025 11:36 - 19.5.2025 23:59
Time of permit ending testing 19.4.2025 11:04.

**1. Permit status before ending after current period:**
![permit before ending](https://github.com/user-attachments/assets/589b036d-b8c9-48e1-9c5a-55de55627ef5)
**2. Permit ending dialog:**
![admin ui end permit dialog](https://github.com/user-attachments/assets/9d4e2215-8688-4583-a1c5-adc7a4ea1ba1)
**3. Overview-page, where the refund is shown:**
![admin ui end permit phase two](https://github.com/user-attachments/assets/5579ac54-c614-4869-a38d-4e673e73e42f)
**4. Permit status after ending after current period:**
![permit after ending](https://github.com/user-attachments/assets/ef8dfe60-7a00-4a13-94a5-afe1c639d74e)
**5. Permit change history updated:**
![permit change history updated](https://github.com/user-attachments/assets/9a1646da-7238-4a89-bc58-284b70ecc56f)

