### PR TITLE
SHPPWS-35: Use permit end time as max dates

### DIFF
--- a/src/components/permitDetail/TemporaryVehicle.tsx
+++ b/src/components/permitDetail/TemporaryVehicle.tsx
@@ -114,7 +114,9 @@ const TemporaryVehicle = ({
                       id="startDate"
                       className="date-input"
                       minDate={new Date()}
-                      maxDate={addWeeks(new Date(), 2)}
+                      maxDate={
+                        permit.endTime ? new Date(permit.endTime) : undefined
+                      }
                       initialMonth={new Date()}
                       value={format(field.value, 'd.M.yyyy')}
                       onChange={(value: string, valueAsDate: Date) =>
@@ -144,6 +146,9 @@ const TemporaryVehicle = ({
                       id="endDate"
                       className="date-input"
                       minDate={form.getFieldProps('startDate').value}
+                      maxDate={
+                        permit.endTime ? new Date(permit.endTime) : undefined
+                      }
                       initialMonth={form.getFieldProps('startDate').value}
                       value={format(field.value, 'd.M.yyyy')}
                       onChange={(value: string, valueAsDate: Date) =>


### PR DESCRIPTION
## Description

Use permit end time as max dates.
Refs: SHPPWS-35

## Screenshots

![admin-change-history](https://github.com/user-attachments/assets/5015d4bd-2279-44b5-a529-eb18fb78bc6b)
