### PR TITLE
feat: use configurable map tile URL template for LocationPicker

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,6 +20,7 @@ REACT_APP_PARKING_PERMITS_GRANT_TYPE="urn:ietf:params:oauth:grant-type:uma-ticke
 REACT_APP_PARKING_PERMITS_BACKEND_URL="http://127.0.0.1:8888"
 REACT_APP_ADDRESS_WFS_URL="https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
 REACT_APP_ADDRESS_WFS_TYPENAMES="avoindata:Helsinki_osoiteluettelo"
+REACT_APP_MAP_URL_TEMPLATE="https://maptiles.api.hel.fi/styles/hel-osm-bright-{language}/{z}/{x}/{y}.png"
 REACT_APP_SENTRY_DSN=""
 REACT_APP_SENTRY_ENVIRONMENT="local-development-unconfigured"
 PARKING_PERMITS_GRAPHQL_API=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ CMD ["yarn", "start"]
 FROM appbase as staticbuilder
 #==============================
 COPY . /app
+
+ARG REACT_APP_MAP_URL_TEMPLATE
+
 RUN yarn build
 
 

--- a/src/components/common/LocationPicker.tsx
+++ b/src/components/common/LocationPicker.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapContainer, Marker, TileLayer, useMapEvents } from 'react-leaflet';
 import marker from '../../assets/images/icon_poi_talo-sininen.svg';
+import { getEnv } from '../../utils';
 import styles from './LocationPicker.module.scss';
 
 const icon = new L.Icon({
@@ -12,14 +13,6 @@ const icon = new L.Icon({
   // eslint-disable-next-line no-magic-numbers
   iconSize: [25, 55],
 });
-
-const FI_ATTRIBUTION =
-  '&copy; Helsingin, Espoon, Vantaan ja Kauniaisen kaupungit';
-const SV_ATTRIBUTION = '&copy; Helsingfors, Esbo, Vanda och Grankulla städer';
-const FI_MAP_URL =
-  'https://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}.png';
-const SV_MAP_URL =
-  'https://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}sv.png';
 
 function flipLocation(location: [number, number]): [number, number] {
   const [lng, lat] = location;
@@ -48,7 +41,11 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   onChange,
   errorText,
 }) => {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const template = getEnv('REACT_APP_MAP_URL_TEMPLATE');
+  const language = ['fi', 'sv'].includes(lang) ? lang : 'fi';
+  const mapUrl = template.replace('{language}', language);
   return (
     <div className={className}>
       <MapContainer
@@ -58,12 +55,10 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
         <MapComponent
           onMapClick={e => onChange([e.latlng.lng, e.latlng.lat])}
         />
-        {i18n.language === 'sv' && (
-          <TileLayer attribution={SV_ATTRIBUTION} url={SV_MAP_URL} />
-        )}
-        {i18n.language !== 'sv' && (
-          <TileLayer attribution={FI_ATTRIBUTION} url={FI_MAP_URL} />
-        )}
+        <TileLayer
+          attribution={t('components.common.locationPicker.mapAttribution')}
+          url={mapUrl}
+        />
         <Marker position={flipLocation(location)} icon={icon} />
       </MapContainer>
       <div className={styles.errorText}>{errorText}</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,6 +12,9 @@
         "editAddress": "Edit",
         "placeholder": "Search address..."
       },
+      "locationPicker": {
+        "mapAttribution": "&copy; Cities of Helsinki, Espoo, Vantaa and Kauniainen"
+      },
       "auth": {
         "login": {
           "login": "Login",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -12,6 +12,9 @@
         "editAddress": "Muokkaa",
         "placeholder": "Hae osoite..."
       },
+      "locationPicker": {
+        "mapAttribution": "&copy; Helsingin, Espoon, Vantaan ja Kauniaisen kaupungit"
+      },
       "auth": {
         "login": {
           "login": "Kirjaudu sisään",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -12,6 +12,9 @@
         "editAddress": "Redigera",
         "placeholder": "Sök adress..."
       },
+      "locationPicker": {
+        "mapAttribution": "&copy; Helsingfors, Esbo, Vanda och Grankulla städer"
+      },
       "auth": {
         "login": {
           "login": "Inloggning",


### PR DESCRIPTION
Replace hardcoded tiles.hel.ninja URLs with REACT_APP_MAP_URL_TEMPLATE env var using a {language} placeholder resolved at render time.
Map attribution strings moved to i18n translation files.
ARG REACT_APP_MAP_URL_TEMPLATE added to Dockerfile staticbuilder stage.

Refs: [PV-992](https://helsinkisolutionoffice.atlassian.net/browse/PV-992)

## Screenshots

![parking-permits-map-fi](https://github.com/user-attachments/assets/05c208f5-0cb2-4fc7-b004-8843d0661786)
![parking-permits-map-sv](https://github.com/user-attachments/assets/1b4eed31-4585-4721-bbb5-f8583c18c6e1)
![parking-permits-map-en](https://github.com/user-attachments/assets/5a9ec0a0-9d49-443a-9375-033f31c6ab83)

[PV-992]: https://helsinkisolutionoffice.atlassian.net/browse/PV-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ